### PR TITLE
Lots of Raid Changes

### DIFF
--- a/Blish HUD/Raids.xml
+++ b/Blish HUD/Raids.xml
@@ -6,178 +6,201 @@
     <MarkerCategory    name="Ti"   DisplayName="Hero's Marker Pack" IsSeparator="1"/>
     <!-- ========== SPIRIT VALE ================================================================================================================================================================================================ -->
     <MarkerCategory     name="W1" DisplayName="Spirit Vale">
-      <MarkerCategory   name="B1" DisplayName="Vale Guardian"              fadeFar="200"  fadeNear="175"/>
-      <MarkerCategory   name="C1" DisplayName="Mushrooms"     behavior="4" fadeFar="3500" fadeNear="3000" hasCountdown="1" iconFile="Data/Multi/empty.png"                                                                      triggerRange="2"/>
+      <MarkerCategory   name="B1" DisplayName="Vale Guardian" fadeFar="200"  fadeNear="175"/>
       <MarkerCategory   name="B2" DisplayName="Spirit Run">
         <MarkerCategory name="c1" DisplayName="Skip"/>
-        <MarkerCategory name="c2" DisplayName="Trigger Lines"              fadeFar="1500" fadeNear="1000"/>
+        <MarkerCategory name="c2" DisplayName="Trigger Lines" fadeFar="1500" fadeNear="1000"/>
       </MarkerCategory>
       <MarkerCategory   name="B3" DisplayName="Gorseval">
-        <MarkerCategory name="c1" DisplayName="Spirits"                    fadeFar="3500" fadeNear="3000"                  iconFile="Data/Multi/dot.png"   iconSize="0.6" rotate-x="180"/>
-        <MarkerCategory name="c2" DisplayName="Boundary"                   fadeFar="175"  fadeNear="150"/>
+        <MarkerCategory name="c1" DisplayName="Boundary"      fadeFar="175"  fadeNear="150"/>
+        <MarkerCategory name="c2" DisplayName="Spirits"       fadeFar="3500" fadeNear="3000" iconFile="Data/Multi/dot.png" iconSize="0.6" rotate-x="180"/>
       </MarkerCategory>
       <MarkerCategory   name="B4" DisplayName="Sabetha">
-        <MarkerCategory name="c1" DisplayName="Directions"                 fadeFar="2750" fadeNear="2250"                                                                 rotate-x="90"/>
-        <MarkerCategory name="c2" DisplayName="Boundary"                   fadeFar="175"  fadeNear="150"/>
+        <MarkerCategory name="c1" DisplayName="Boundary"      fadeFar="200"  fadeNear="175"/>
+        <MarkerCategory name="c2" DisplayName="Directions"    fadeFar="2750" fadeNear="2250"                                              rotate-x="90"/>
       </MarkerCategory>
-      <MarkerCategory   name="Ch" DisplayName="Chests"        behavior="2"                                                 iconFile="Data/Multi/empty.png" iconSize="0.5" rotate-x="90"                                         triggerRange="3"/>
     </MarkerCategory>
     <!-- ========== SALVATION PASS ============================================================================================================================================================================================= -->
     <MarkerCategory     name="W2" DisplayName="Salvation Pass">
-      <MarkerCategory   name="B1" DisplayName="Slothasor"                   fadeFar="3500" fadeNear="3250"                                      iconSize="1">
+      <MarkerCategory   name="B1" DisplayName="Slothasor"      fadeFar="3500" fadeNear="3250"                                      iconSize="1">
         <MarkerCategory name="c1" DisplayName="Mushrooms"/>
+        <MarkerCategory name="c2" DisplayName="Timer"          fadeFar="1250" fadeNear="1000" iconFile="Data/Raids/starttimer.png" iconSize="1"/>
       </MarkerCategory>
-      <MarkerCategory   name="B2" DisplayName="Trio"                        fadeFar="4750" fadeNear="4500"/>
-      <MarkerCategory   name="B3" DisplayName="Matthias"                    fadeFar="2750" fadeNear="2500">
-        <MarkerCategory name="c1" DisplayName="Wells"                                                                                           iconSize="0.5" rotate-x="125"/>
-        <MarkerCategory name="c3" DisplayName="Boundary"                    fadeFar="150"  fadeNear="125"/>
+      <MarkerCategory   name="B2" DisplayName="Trio"           fadeFar="4750" fadeNear="4500"/>
+      <MarkerCategory   name="B3" DisplayName="Matthias"       fadeFar="2750" fadeNear="2500">
+        <MarkerCategory name="c1" DisplayName="Boundary"       fadeFar="150"  fadeNear="125"/>
+        <MarkerCategory name="c2" DisplayName="Timer"          fadeFar="1250" fadeNear="1000" iconFile="Data/Raids/starttimer.png" iconSize="1"/>
+        <MarkerCategory name="c3" DisplayName="Wells"                                                                              iconSize="0.5" rotate-x="125"/>
       </MarkerCategory>
-      <MarkerCategory   name="Ch" DisplayName="Chests"         behavior="2"                                iconFile="Data/Multi/empty.png"      iconSize="0.6"                                                                          triggerRange="3"/>
     </MarkerCategory>
     <!-- ========== STRONGHOLD OF THE FAITHFUL ================================================================================================================================================================================= -->
     <MarkerCategory       name="W3" DisplayName="Stronghold of the Faithful">
-      <MarkerCategory     name="B2" DisplayName="Keep Construct"                          fadeFar="2500" fadeNear="2000"                                 iconSize="0.5"  rotate-x="180">
-        <MarkerCategory   name="c1" DisplayName="Green Circles"                                                          iconFile="Data/Multi/stack.png"/>
-        <MarkerCategory   name="c2" DisplayName="Rifts"                                                                  iconFile="Data/Multi/dot.png"/>
-        <MarkerCategory   name="c3" DisplayName="1-orb Pull"                                                             iconFile="Data/Multi/stack.png"/>
-        <MarkerCategory   name="c4" DisplayName="Boundary"                                fadeFar="175"  fadeNear="150"/>
+      <MarkerCategory     name="B2" DisplayName="Keep Construct"             fadeFar="2500" fadeNear="2000"                                 iconSize="0.5"  rotate-x="180">
+        <MarkerCategory   name="c1" DisplayName="Boundary"                   fadeFar="175"  fadeNear="150"/>
+        <MarkerCategory   name="c2" DisplayName="Green Circles"                                             iconFile="Data/Multi/stack.png"/>
+        <MarkerCategory   name="c3" DisplayName="Rifts"                                                     iconFile="Data/Multi/dot.png"/>
+        <MarkerCategory   name="c4" DisplayName="1-orb Pull"                                                iconFile="Data/Multi/stack.png"/>
       </MarkerCategory>
         <MarkerCategory   name="B3" DisplayName="Twisted Castle">
-          <MarkerCategory name="c1" DisplayName="1st Button Skip"                         fadeFar="1750" fadeNear="1250"/>
-          <MarkerCategory name="c2" DisplayName="Buttons"                                                                                                iconSize="0.75"/>
-          <MarkerCategory name="c3" DisplayName="Button Paths"                                                                                           iconSize="0.5"/>
+          <MarkerCategory name="c1" DisplayName="1st Button Skip"            fadeFar="1750" fadeNear="1250"/>
+          <MarkerCategory name="c2" DisplayName="Buttons"                                                                                   iconSize="0.75"/>
+          <MarkerCategory name="c3" DisplayName="Button Paths"                                                                              iconSize="0.5"/>
         </MarkerCategory>
-      <MarkerCategory     name="B4" DisplayName="Xera"                                    fadeFar="3000" fadeNear="2500"                                 iconSize="1"    rotate-x="90"/>
-      <MarkerCategory     name="Ch" DisplayName="Chests"                     behavior="2" fadeFar="2000" fadeNear="1500" iconFile="Data/Multi/empty.png" iconSize="1"    rotate-x="90"                                                         triggerRange="3"/>
+      <MarkerCategory     name="B4" DisplayName="Xera"                       fadeFar="3000" fadeNear="2500"                                 iconSize="1"    rotate-x="90"/>
     </MarkerCategory>
     <!-- ========== BASTION OF THE PENITENT ==================================================================================================================================================================================== -->
     <MarkerCategory     name="W4" DisplayName="Bastion of the Penitent">
-      <MarkerCategory   name="B1" DisplayName="Cairn"                                fadeFar="4000" fadeNear="3500"                                        iconSize="0.5"  rotate-x="180"/>
-      <MarkerCategory   name="C1" DisplayName="Samarog's Door"          behavior="6" fadeFar="1500" fadeNear="1250" iconFile="Data/Raids/W4/TrueSight.png" iconSize="0.35"/>
-      <MarkerCategory   name="B3" DisplayName="Samarog"                              fadeFar="275"  fadeNear="250"/>
-      <MarkerCategory   name="Ch" DisplayName="Chests"                  behavior="2"                                iconFile="Data/Multi/empty.png"        iconSize="0.75"                                                                                   triggerRange="3"/>
+      <MarkerCategory   name="B1" DisplayName="Cairn"                   fadeFar="4000" fadeNear="3500">
+        <MarkerCategory name="c1" DisplayName="Agony"                                                                                         iconSize="0.5"  rotate-x="180"/>
+        <MarkerCategory name="c2" DisplayName="Timer"                                                  iconFile="Data/Raids/starttimer.png"   iconSize="1"/>
+      </MarkerCategory>
+      <MarkerCategory   name="B2" DisplayName="Mursaat Overseer"        fadeFar="1500" fadeNear="1250" iconFile="Data/Raids/starttimer.png"   iconSize="1"/>
+      <MarkerCategory   name="B3" DisplayName="Samarog">
+        <MarkerCategory name="c1" DisplayName="Boundary"                fadeFar="275"  fadeNear="250"/>
+        <MarkerCategory name="c2" DisplayName="Door"                    fadeFar="1500" fadeNear="1250" iconFile="Data/Raids/W4/TrueSight.png" iconSize="0.35"/>
+        <MarkerCategory name="c3" DisplayName="Timer"                   fadeFar="1050" fadeNear="800"  iconFile="Data/Raids/starttimer.png"   iconSize="1"/>
+      </MarkerCategory>
     </MarkerCategory>
     <!-- ========== HALL OF CHAINS ============================================================================================================================================================================================= -->
     <MarkerCategory       name="W5" DisplayName="Hall of Chains">
-      <MarkerCategory     name="B1" DisplayName="Soulless Horror"                                                                                iconSize="1" rotate-x="180"/>
+      <MarkerCategory     name="B1" DisplayName="Soulless Horror"                                   fadeFar="4000" fadeNear="3750"                                      iconSize="1"    rotate-x="90"/>
         <MarkerCategory   name="B3" DisplayName="Statues">
-          <MarkerCategory name="c1" DisplayName="Broken King"                     fadeFar="3500" fadeNear="3000" iconFile="Data/Multi/dot.png"   iconSize="0.75" rotate-x="180"/>
-          <MarkerCategory name="c2" DisplayName="Statue of Darkness"              fadeFar="3000" fadeNear="2800" iconFile="Data/Multi/dot.png"   iconSize="0.5"  rotate-x="180" rotate-z="-15"/>
+          <MarkerCategory name="c1" DisplayName="Broken King"                                       fadeFar="3500" fadeNear="3000" iconFile="Data/Multi/dot.png"        iconSize="0.75" rotate-x="180"/>
+          <MarkerCategory name="c2" DisplayName="Statue of Darkness"                                fadeFar="3000" fadeNear="2800" iconFile="Data/Multi/dot.png"        iconSize="0.5"  rotate-x="180" rotate-z="-15"/>
         </MarkerCategory>
       <MarkerCategory     name="B4" DisplayName="Dhuum">
-        <MarkerCategory   name="c1" DisplayName="Reapers"                         fadeFar="4000" fadeNear="3500"                                                 rotate-x="180"/>
-        <MarkerCategory   name="c3" DisplayName="Death AoE"                       fadeFar="2000" fadeNear="1650"/>                  
+        <MarkerCategory   name="c1" DisplayName="Greens"             behavior="1"                   fadeFar="4000" fadeNear="3500"                                      iconSize="1"                                  triggerRange="6">
+          <MarkerCategory name="g1" DisplayName="One"/>
+          <MarkerCategory name="g2" DisplayName="Two"                             defaultToggle="0"/>
+          <MarkerCategory name="g3" DisplayName="Three"                           defaultToggle="0"/>
+        </MarkerCategory>
+        <MarkerCategory   name="c2" DisplayName="Death AoE"                                         fadeFar="2000" fadeNear="1650"/>
+        <MarkerCategory   name="c3" DisplayName="Timer"                                             fadeFar="2000" fadeNear="1750" iconFile="Data/Raids/starttimer.png" iconSize="1"/>
       </MarkerCategory>
-      <MarkerCategory     name="Ch" DisplayName="Chests"             behavior="2"                                iconFile="Data/Multi/empty.png" iconSize="1"                                                                              triggerRange="3"/>
     </MarkerCategory>
     <!-- ========== MYTHWRIGHT GAMBIT ========================================================================================================================================================================================== -->
     <MarkerCategory       name="W6" DisplayName="Mythwright Gambit">
       <MarkerCategory     name="B1" DisplayName="Conjured Amalgamate">
-        <MarkerCategory   name="c1" DisplayName="Shield/Sword"                                                                                                         fadeFar="3000" fadeNear="2500"                                 iconSize="0.75" rotate-x="180"/>
-        <MarkerCategory   name="c2" DisplayName="Boundary"                                                                                                             fadeFar="150"  fadeNear="125"/>
+        <MarkerCategory   name="c1" DisplayName="Boundary"                                                                                                fadeFar="150"  fadeNear="125"/>
+        <MarkerCategory   name="c2" DisplayName="Shield/Sword"                                                                                            fadeFar="3000" fadeNear="2500"                                iconSize="0.75" rotate-x="180"/>
       </MarkerCategory>
-      <MarkerCategory     name="B2" DisplayName="Twin Largos"                      bounce-duration="120" bounce-distance="43" bounce-height="-31" bounce-when="inzone" fadeFar="2000" fadeNear="1750"                                                 rotate-x="90"                             title-color="yellow"/>
+      <MarkerCategory     name="B2" DisplayName="Twin Largos"         bounce-duration="120" bounce-distance="43" bounce-height="-31" bounce-when="inzone" fadeFar="2000" fadeNear="1750"                                                rotate-x="90"  title-color="yellow"/>
       <MarkerCategory     name="B3" DisplayName="Qadim">
-        <MarkerCategory   name="c1" DisplayName="Pyre Boons"                                                                                                           fadeFar="5000" fadeNear="4500"                                 iconSize="0.75"/>
-        <MarkerCategory   name="c2" DisplayName="Lamp"                                                                                                                 fadeFar="3000" fadeNear="2000"                                                 rotate-x="180">
-          <MarkerCategory name="L1" DisplayName="1st Path"                                                                                                                                            iconFile="Data/Raids/W6/1.png"/>
-          <MarkerCategory name="L2" DisplayName="2nd Path"                                                                                                                                            iconFile="Data/Raids/W6/2.png"/>
-          <MarkerCategory name="L3" DisplayName="3rd Path"                                                                                                                                            iconFile="Data/Raids/W6/3.png"/>
+        <MarkerCategory   name="c1" DisplayName="Boon Pyres"                                                                                              fadeFar="5000" fadeNear="4500"                                iconSize="0.75"/>
+        <MarkerCategory   name="c2" DisplayName="Lamp"                                                                                                    fadeFar="3000" fadeNear="2000"                                                rotate-x="180">
+          <MarkerCategory name="L1" DisplayName="1st Path"                                                                                                                               iconFile="Data/Raids/W6/1.png"/>
+          <MarkerCategory name="L2" DisplayName="2nd Path"                                                                                                                               iconFile="Data/Raids/W6/2.png"/>
+          <MarkerCategory name="L3" DisplayName="3rd Path"                                                                                                                               iconFile="Data/Raids/W6/3.png"/>
         </MarkerCategory>
       </MarkerCategory>
-      <MarkerCategory     name="Ch" DisplayName="Chests"              behavior="2"                                                                                     fadeFar="1500" fadeNear="1250" iconFile="Data/Multi/empty.png" iconSize="1"    rotate-x="90"                                                  triggerRange="3"/>
     </MarkerCategory>
     <!-- ========== THE KEY OF AHDASHIM ======================================================================================================================================================================================== -->
     <MarkerCategory     name="W7" DisplayName="The Key of Ahdashim">
-      <MarkerCategory   name="B1" DisplayName="Cardinal Sabir"      fadeFar="125"  fadeNear="100"/>
-      <MarkerCategory   name="B2" DisplayName="Cardinal Adina"      fadeFar="3250" fadeNear="2750">
+      <MarkerCategory   name="B1" DisplayName="Cardinal Adina"      fadeFar="3250" fadeNear="2750">
         <MarkerCategory name="c1" DisplayName="Directions"                                                                                       rotate-x="90"/>
         <MarkerCategory name="c2" DisplayName="Pillar Locations"                                   iconFile="Data/Multi/dot.png" iconSize="0.5"  rotate-x="180"/>
       </MarkerCategory>
+      <MarkerCategory   name="B2" DisplayName="Cardinal Sabir"      fadeFar="125"  fadeNear="100"/>
       <MarkerCategory   name="B3" DisplayName="Qadim the Peerless"  fadeFar="5500" fadeNear="5000">
-        <MarkerCategory name="c1" DisplayName="Pylons"                                                                           iconSize="1"/>
-        <MarkerCategory name="c2" DisplayName="Fire Placements"                                    iconFile="Data/Multi/dot.png" iconSize="0.75" rotate-x="180"/>
+        <MarkerCategory name="c1" DisplayName="Fire Placements"                                    iconFile="Data/Multi/dot.png" iconSize="0.75" rotate-x="180"/>
+        <MarkerCategory name="c2" DisplayName="Pylons"                                                                           iconSize="1"/>
       </MarkerCategory>
     </MarkerCategory>
   </MarkerCategory>
     
   <POIs>    
     <!-- ======================================== SPIRIT VALE ================================================================================================================================================================== -->
-    <!-- ==================== Mushrooms ==================== -->
-    <!-- Speed -->
-    <POI MapID="1062" xpos="-091.070" ypos="60.937" zpos="-506.081" GUID="trI4Ikkxf0uEl0Of2dGZUg==" type="Raid.W1.C1" resetLength="20"/>
-    <POI MapID="1062" xpos="-151.658" ypos="60.937" zpos="-507.339" GUID="VVruJ+afv0CW7XgO9/unJg==" type="Raid.W1.C1" resetLength="20"/>
-    <POI MapID="1062" xpos="-121.094" ypos="60.937" zpos="-559.273" GUID="OCw6WOaUKEqltHMKIqH3aA==" type="Raid.W1.C1" resetLength="20"/>
-    <!-- Adrenal -->
-    <POI MapID="1062" xpos="-109.085" ypos="42.403" zpos="-355.932" GUID="CVvJijVfQ0q3Eq91Jp4EUQ==" type="Raid.W1.C1" resetLength="30.9"/>
-    <POI MapID="1062" xpos="-063.033" ypos="36.012" zpos="-328.275" GUID="otxqOJuKkU2UIroCyDomnA==" type="Raid.W1.C1" resetLength="30.9"/>
     <!-- ==================== Spirit Woods Skip ==================== -->
-    <POI MapID="1062" xpos="-127.456" ypos="67.100" zpos="-420.086" GUID="HHgLEkJk9EGjZJ88sefs3Q==" type="Raid.W1.B2.c1" fadeFar="500"  fadeNear="350"  iconFile="Data/Raids/raid1.png"  iconSize="0.25" rotate-x="90"                 rotate-z="-45"/>
-	<POI MapID="1062" xpos="-126.476" ypos="68.076" zpos="-408.575" GUID="3+rbwMnEPkWgnf1Z178l2g==" type="Raid.W1.B2.c1" fadeFar="650"  fadeNear="500"  iconFile="Data/Raids/raid1.png"  iconSize="0.4"  rotate-x="45"                 rotate-z="75"/>
-	<POI MapID="1062" xpos="-098.713" ypos="67.701" zpos="-403.031" GUID="dfGPEGhY8E+rf6y9d8uMfQ==" type="Raid.W1.B2.c1" fadeFar="1750" fadeNear="1500" iconFile="Data/Raids/raid1.png"  iconSize="0.5"  rotate-x="135" rotate-y="15"  rotate-z="100"/>
-	<POI MapID="1062" xpos="-072.768" ypos="77.832" zpos="-435.116" GUID="6KOdRRwW/0yzRIweCmHXFw==" type="Raid.W1.B2.c1" fadeFar="1900" fadeNear="1750" iconFile="Data/Raids/raid2.png"  iconSize="0.35" rotate-x="90"  rotate-y="85"  rotate-z="55"/>
-    <POI MapID="1062" xpos="-102.409" ypos="92.306" zpos="-447.787" GUID="csYKUmvMIUq/iaw4EMtoIA==" type="Raid.W1.B2.c1" fadeFar="1500" fadeNear="1250" iconFile="Data/Raids/raid1.png"  iconSize="0.4"  rotate-x="85"                 rotate-z="-50"/>
-	<POI MapID="1062" xpos="-123.918" ypos="85.785" zpos="-428.059" GUID="V7guHrTR302v1sxsDwXVuw==" type="Raid.W1.B2.c1" fadeFar="1400" fadeNear="1250" iconFile="Data/Raids/raid1.png"  iconSize="0.25" rotate-x="110"                rotate-z="140"/>
-	<POI MapID="1062" xpos="-124.429" ypos="88.818" zpos="-422.896" GUID="nQLT2p05MU6Wj0C8Muos6Q==" type="Raid.W1.B2.c1" fadeFar="1500" fadeNear="1350" iconFile="Data/Raids/raid1.png"  iconSize="0.25" rotate-x="125"                rotate-z="270"/>
-	<POI MapID="1062" xpos="-119.832" ypos="86.679" zpos="-392.791" GUID="Ei0Vbpo9k0edW46b/V3CZA==" type="Raid.W1.B2.c1" fadeFar="1250" fadeNear="1000" iconFile="Data/Raids/raid1.png"  iconSize="0.5"/>
-	<POI MapID="1062" xpos="-118.088" ypos="77.829" zpos="-367.392" GUID="/w8x9WdxxEGXYjlYMDqNmw==" type="Raid.W1.B2.c1" fadeFar="1500" fadeNear="1250" iconFile="Data/Raids/raid1.png"  iconSize="0.5"/>
-	<POI MapID="1062" xpos="-131.938" ypos="69.587" zpos="-344.961" GUID="cbamHZaR5EaZGbQhX1jlZg==" type="Raid.W1.B2.c1" fadeFar="1500" fadeNear="1250" iconFile="Data/Raids/raid1.png"  iconSize="0.5"/>
-	<POI MapID="1062" xpos="-149.802" ypos="63.236" zpos="-339.373" GUID="aU1U2VKT50OkOn2qWFivEA==" type="Raid.W1.B2.c1" fadeFar="1250" fadeNear="1000" iconFile="Data/Raids/raid1.png"  iconSize="0.5"  rotate-x="135"                rotate-z="270"/>
-	<POI MapID="1062" xpos="-144.494" ypos="63.565" zpos="-298.878" GUID="PxDJXui+V0Cav5RLP951AA==" type="Raid.W1.B2.c1" fadeFar="1200" fadeNear="1050" iconFile="Data/Raids/raid1.png"  iconSize="0.4"  rotate-x="90"                 rotate-z="250"/>
-    <POI MapID="1062" xpos="-126.290" ypos="39.724" zpos="-302.780" GUID="PMxMkPr1b06ESA0JhxhyTw==" type="Raid.W1.B2.c1" fadeFar="650"  fadeNear="500"  iconFile="Data/Fracs/pExit.png"  iconSize="0.5"  rotate-x="175" rotate-y="0"   rotate-z="260"/>
-    <POI MapID="1062" xpos="-129.484" ypos="58.183" zpos="-266.982" GUID="DKyVQvAJZ0iQkgyp+ISFKQ==" type="Raid.W1.B2.c1" fadeFar="1750" fadeNear="1500" iconFile="Data/Fracs/pEnter.png" iconSize="0.5"  rotate-x="190" rotate-y="-10" rotate-z="50"/>
-	<POI MapID="1062" xpos="-204.820" ypos="54.392" zpos="-316.286" GUID="va7mQJkH5k2lNMnN80WoAg==" type="Raid.W1.B2.c1" fadeFar="500"  fadeNear="350"  iconFile="Data/Fracs/pEnter.png" iconSize="0.5"  rotate-x="180"                rotate-z="-70"/>
-    <POI MapID="1062" xpos="-223.454" ypos="63.808" zpos="-238.694" GUID="T85IWFQJVkacSr8bses52w==" type="Raid.W1.B2.c1" fadeFar="500"  fadeNear="350"  iconFile="Data/Fracs/pEnter.png" iconSize="0.5"  rotate-x="160"                rotate-z="190"/>
+    <!-- Mesmer -->
+    <POI MapID="1062" xpos="-127.456" ypos="67.100" zpos="-420.086" GUID="HHgLEkJk9EGjZJ88sefs3Q==" type="Raid.W1.B2.c1" fadeFar="500"  fadeNear="350"  iconFile="Data/Raids/raid1.png"  iconSize="0.25" profession="mesmer" rotate-x="90"                 rotate-z="-45"/>
+	<POI MapID="1062" xpos="-126.476" ypos="68.076" zpos="-408.575" GUID="3+rbwMnEPkWgnf1Z178l2g==" type="Raid.W1.B2.c1" fadeFar="650"  fadeNear="500"  iconFile="Data/Raids/raid1.png"  iconSize="0.4"  profession="mesmer" rotate-x="45"                 rotate-z="75"/>
+	<POI MapID="1062" xpos="-098.713" ypos="67.701" zpos="-403.031" GUID="dfGPEGhY8E+rf6y9d8uMfQ==" type="Raid.W1.B2.c1" fadeFar="1750" fadeNear="1500" iconFile="Data/Raids/raid1.png"  iconSize="0.5"  profession="mesmer" rotate-x="135" rotate-y="15"  rotate-z="100"/>
+	<POI MapID="1062" xpos="-072.768" ypos="77.832" zpos="-435.116" GUID="6KOdRRwW/0yzRIweCmHXFw==" type="Raid.W1.B2.c1" fadeFar="1900" fadeNear="1750" iconFile="Data/Raids/raid2.png"  iconSize="0.35" profession="mesmer" rotate-x="90"  rotate-y="85"  rotate-z="55"/>
+    <POI MapID="1062" xpos="-102.409" ypos="92.306" zpos="-447.787" GUID="csYKUmvMIUq/iaw4EMtoIA==" type="Raid.W1.B2.c1" fadeFar="1500" fadeNear="1250" iconFile="Data/Raids/raid1.png"  iconSize="0.4"  profession="mesmer" rotate-x="85"                 rotate-z="-50"/>
+	<POI MapID="1062" xpos="-123.918" ypos="85.785" zpos="-428.059" GUID="V7guHrTR302v1sxsDwXVuw==" type="Raid.W1.B2.c1" fadeFar="1400" fadeNear="1250" iconFile="Data/Raids/raid1.png"  iconSize="0.25" profession="mesmer" rotate-x="110"                rotate-z="140"/>
+	<POI MapID="1062" xpos="-124.429" ypos="88.818" zpos="-422.896" GUID="nQLT2p05MU6Wj0C8Muos6Q==" type="Raid.W1.B2.c1" fadeFar="1500" fadeNear="1350" iconFile="Data/Raids/raid1.png"  iconSize="0.25" profession="mesmer" rotate-x="125"                rotate-z="270"/>
+	<POI MapID="1062" xpos="-119.832" ypos="86.679" zpos="-392.791" GUID="Ei0Vbpo9k0edW46b/V3CZA==" type="Raid.W1.B2.c1" fadeFar="1250" fadeNear="1000" iconFile="Data/Raids/raid1.png"  iconSize="0.5"  profession="mesmer" />
+	<POI MapID="1062" xpos="-118.088" ypos="77.829" zpos="-367.392" GUID="/w8x9WdxxEGXYjlYMDqNmw==" type="Raid.W1.B2.c1" fadeFar="1500" fadeNear="1250" iconFile="Data/Raids/raid1.png"  iconSize="0.5"  profession="mesmer" />
+	<POI MapID="1062" xpos="-131.938" ypos="69.587" zpos="-344.961" GUID="cbamHZaR5EaZGbQhX1jlZg==" type="Raid.W1.B2.c1" fadeFar="1500" fadeNear="1250" iconFile="Data/Raids/raid1.png"  iconSize="0.5"  profession="mesmer" />
+	<POI MapID="1062" xpos="-149.802" ypos="63.236" zpos="-339.373" GUID="aU1U2VKT50OkOn2qWFivEA==" type="Raid.W1.B2.c1" fadeFar="1250" fadeNear="1000" iconFile="Data/Raids/raid1.png"  iconSize="0.5"  profession="mesmer" rotate-x="135"                rotate-z="270"/>
+	<POI MapID="1062" xpos="-144.494" ypos="63.565" zpos="-298.878" GUID="PxDJXui+V0Cav5RLP951AA==" type="Raid.W1.B2.c1" fadeFar="1200" fadeNear="1050" iconFile="Data/Raids/raid1.png"  iconSize="0.4"  profession="mesmer" rotate-x="90"                 rotate-z="250"/>
+    <POI MapID="1062" xpos="-126.290" ypos="39.724" zpos="-302.780" GUID="PMxMkPr1b06ESA0JhxhyTw==" type="Raid.W1.B2.c1" fadeFar="650"  fadeNear="500"  iconFile="Data/Fracs/pExit.png"  iconSize="0.5"  profession="mesmer" rotate-x="175" rotate-y="0"   rotate-z="260"/>
+    <POI MapID="1062" xpos="-129.484" ypos="58.183" zpos="-266.982" GUID="DKyVQvAJZ0iQkgyp+ISFKQ==" type="Raid.W1.B2.c1" fadeFar="1750" fadeNear="1500" iconFile="Data/Fracs/pEnter.png" iconSize="0.5"  profession="mesmer" rotate-x="190" rotate-y="-10" rotate-z="50"/>
+	<POI MapID="1062" xpos="-204.820" ypos="54.392" zpos="-316.286" GUID="va7mQJkH5k2lNMnN80WoAg==" type="Raid.W1.B2.c1" fadeFar="500"  fadeNear="350"  iconFile="Data/Fracs/pEnter.png" iconSize="0.5"  profession="mesmer" rotate-x="180"                rotate-z="-70"/>
+    <POI MapID="1062" xpos="-223.454" ypos="63.808" zpos="-238.694" GUID="T85IWFQJVkacSr8bses52w==" type="Raid.W1.B2.c1" fadeFar="500"  fadeNear="350"  iconFile="Data/Fracs/pEnter.png" iconSize="0.5"  profession="mesmer" rotate-x="160"                rotate-z="190"/>
+    <!-- Thief -->
+    <POI MapID="1062" xpos="-127.456" ypos="67.100" zpos="-420.086" GUID="HHgLEkJk9EGjZJ88sefs3Q==" type="Raid.W1.B2.c1" fadeFar="500"  fadeNear="350"  iconFile="Data/Raids/raid1.png"  iconSize="0.25" profession="thief"  rotate-x="90"                 rotate-z="-45"/>
+	<POI MapID="1062" xpos="-126.476" ypos="68.076" zpos="-408.575" GUID="3+rbwMnEPkWgnf1Z178l2g==" type="Raid.W1.B2.c1" fadeFar="650"  fadeNear="500"  iconFile="Data/Raids/raid1.png"  iconSize="0.4"  profession="thief"  rotate-x="45"                 rotate-z="75"/>
+	<POI MapID="1062" xpos="-098.713" ypos="67.701" zpos="-403.031" GUID="dfGPEGhY8E+rf6y9d8uMfQ==" type="Raid.W1.B2.c1" fadeFar="1750" fadeNear="1500" iconFile="Data/Raids/raid1.png"  iconSize="0.5"  profession="thief"  rotate-x="135" rotate-y="15"  rotate-z="100"/>
+	<POI MapID="1062" xpos="-072.768" ypos="77.832" zpos="-435.116" GUID="6KOdRRwW/0yzRIweCmHXFw==" type="Raid.W1.B2.c1" fadeFar="1900" fadeNear="1750" iconFile="Data/Raids/raid2.png"  iconSize="0.35" profession="thief"  rotate-x="90"  rotate-y="85"  rotate-z="55"/>
+    <POI MapID="1062" xpos="-102.409" ypos="92.306" zpos="-447.787" GUID="csYKUmvMIUq/iaw4EMtoIA==" type="Raid.W1.B2.c1" fadeFar="1500" fadeNear="1250" iconFile="Data/Raids/raid1.png"  iconSize="0.4"  profession="thief"  rotate-x="85"                 rotate-z="-50"/>
+	<POI MapID="1062" xpos="-123.918" ypos="85.785" zpos="-428.059" GUID="V7guHrTR302v1sxsDwXVuw==" type="Raid.W1.B2.c1" fadeFar="1400" fadeNear="1250" iconFile="Data/Raids/raid1.png"  iconSize="0.25" profession="thief"  rotate-x="110"                rotate-z="140"/>
+	<POI MapID="1062" xpos="-124.429" ypos="88.818" zpos="-422.896" GUID="nQLT2p05MU6Wj0C8Muos6Q==" type="Raid.W1.B2.c1" fadeFar="1500" fadeNear="1350" iconFile="Data/Raids/raid1.png"  iconSize="0.25" profession="thief"  rotate-x="125"                rotate-z="270"/>
+	<POI MapID="1062" xpos="-119.832" ypos="86.679" zpos="-392.791" GUID="Ei0Vbpo9k0edW46b/V3CZA==" type="Raid.W1.B2.c1" fadeFar="1250" fadeNear="1000" iconFile="Data/Raids/raid1.png"  iconSize="0.5"  profession="thief"/>
+	<POI MapID="1062" xpos="-118.088" ypos="77.829" zpos="-367.392" GUID="/w8x9WdxxEGXYjlYMDqNmw==" type="Raid.W1.B2.c1" fadeFar="1500" fadeNear="1250" iconFile="Data/Raids/raid1.png"  iconSize="0.5"  profession="thief"/>
+	<POI MapID="1062" xpos="-131.938" ypos="69.587" zpos="-344.961" GUID="cbamHZaR5EaZGbQhX1jlZg==" type="Raid.W1.B2.c1" fadeFar="1500" fadeNear="1250" iconFile="Data/Raids/raid1.png"  iconSize="0.5"  profession="thief"/>
+	<POI MapID="1062" xpos="-149.802" ypos="63.236" zpos="-339.373" GUID="aU1U2VKT50OkOn2qWFivEA==" type="Raid.W1.B2.c1" fadeFar="1250" fadeNear="1000" iconFile="Data/Raids/raid1.png"  iconSize="0.5"  profession="thief"  rotate-x="135"                rotate-z="270"/>
+	<POI MapID="1062" xpos="-144.494" ypos="63.565" zpos="-298.878" GUID="PxDJXui+V0Cav5RLP951AA==" type="Raid.W1.B2.c1" fadeFar="1200" fadeNear="1050" iconFile="Data/Raids/raid1.png"  iconSize="0.4"  profession="thief"  rotate-x="90"                 rotate-z="250"/>
+    <POI MapID="1062" xpos="-126.290" ypos="39.724" zpos="-302.780" GUID="PMxMkPr1b06ESA0JhxhyTw==" type="Raid.W1.B2.c1" fadeFar="650"  fadeNear="500"  iconFile="Data/Fracs/pExit.png"  iconSize="0.5"  profession="thief"  rotate-x="175" rotate-y="0"   rotate-z="260"/>
+    <POI MapID="1062" xpos="-129.484" ypos="58.183" zpos="-266.982" GUID="DKyVQvAJZ0iQkgyp+ISFKQ==" type="Raid.W1.B2.c1" fadeFar="1750" fadeNear="1500" iconFile="Data/Fracs/pEnter.png" iconSize="0.5"  profession="thief"  rotate-x="190" rotate-y="-10" rotate-z="50"/>
+	<POI MapID="1062" xpos="-204.820" ypos="54.392" zpos="-316.286" GUID="va7mQJkH5k2lNMnN80WoAg==" type="Raid.W1.B2.c1" fadeFar="500"  fadeNear="350"  iconFile="Data/Fracs/pEnter.png" iconSize="0.5"  profession="thief"  rotate-x="180"                rotate-z="-70"/>
+    <POI MapID="1062" xpos="-223.454" ypos="63.808" zpos="-238.694" GUID="T85IWFQJVkacSr8bses52w==" type="Raid.W1.B2.c1" fadeFar="500"  fadeNear="350"  iconFile="Data/Fracs/pEnter.png" iconSize="0.5"  profession="thief"  rotate-x="160"                rotate-z="190"/>
     <!-- ==================== Gorseval ==================== -->
     <!-- Spirits -->
-    <POI MapID="1062" xpos="0022.168" ypos="48.572" zpos="-093.483" GUID="oEXylxHkdkWsf+eMfVVQIw==" type="Raid.W1.B3.c1"                                                                                 rotate-x="180"                rotate-z="220"/>
-    <POI MapID="1062" xpos="0062.549" ypos="48.908" zpos="-091.347" GUID="hGFPtRl7OE6JGHcwC8F18Q==" type="Raid.W1.B3.c1"                                                                                 rotate-z="135"/>
+    <POI MapID="1062" xpos="0022.168" ypos="48.572" zpos="-093.483" GUID="oEXylxHkdkWsf+eMfVVQIw==" type="Raid.W1.B3.c2"                                                                                 rotate-x="180"                rotate-z="220"/>
+    <POI MapID="1062" xpos="0062.549" ypos="48.908" zpos="-091.347" GUID="hGFPtRl7OE6JGHcwC8F18Q==" type="Raid.W1.B3.c2"                                                                                                               rotate-z="135"/>
+    <POI MapID="1062" xpos="0062.083" ypos="48.868" zpos="-132.221" GUID="VVK/FtYXK0COctneNDDPqg==" type="Raid.W1.B3.c2"                                                                                 rotate-x="180"/>
+	<POI MapID="1062" xpos="0021.915" ypos="48.618" zpos="-134.613" GUID="0grnFvQGQ0W1GJSM2wXfbA==" type="Raid.W1.B3.c2"                                                                                 rotate-x="180"/>
     <!-- ==================== Sabetha ==================== -->
     <!-- Directions -->
-    <POI MapID="1062" xpos="-133.137" ypos="62.740" zpos="0052.152" GUID="T08Wbp3oZ0KZ9KzU1Gnfqw==" type="Raid.W1.B4.c1"                                iconFile="Data/Multi/s.png"                                                    rotate-z="-5"/>
-    <POI MapID="1062" xpos="-097.847" ypos="62.884" zpos="0080.927" GUID="7AZv3By300CwPslLkQaEnw==" type="Raid.W1.B4.c1"                                iconFile="Data/Multi/e.png"                                                    rotate-z="85"/>
-    <POI MapID="1062" xpos="-126.366" ypos="62.686" zpos="0116.039" GUID="xxtnBLbCIEuoxx5nBpDqSA==" type="Raid.W1.B4.c1"                                iconFile="Data/Multi/n.png"                                                    rotate-z="175"/>
-    <POI MapID="1062" xpos="-161.633" ypos="62.066" zpos="0087.343" GUID="+oNUkf6Qx0KK4u9MhYitew==" type="Raid.W1.B4.c1"                                iconFile="Data/Multi/w.png"                                                    rotate-z="265"/>
+    <POI MapID="1062" xpos="-133.137" ypos="62.740" zpos="0052.152" GUID="T08Wbp3oZ0KZ9KzU1Gnfqw==" type="Raid.W1.B4.c2"                                iconFile="Data/Multi/s.png"                                                    rotate-z="-5"/>
+    <POI MapID="1062" xpos="-097.847" ypos="62.884" zpos="0080.927" GUID="7AZv3By300CwPslLkQaEnw==" type="Raid.W1.B4.c2"                                iconFile="Data/Multi/e.png"                                                    rotate-z="85"/>
+    <POI MapID="1062" xpos="-126.366" ypos="62.686" zpos="0116.039" GUID="xxtnBLbCIEuoxx5nBpDqSA==" type="Raid.W1.B4.c2"                                iconFile="Data/Multi/n.png"                                                    rotate-z="175"/>
+    <POI MapID="1062" xpos="-161.633" ypos="62.066" zpos="0087.343" GUID="+oNUkf6Qx0KK4u9MhYitew==" type="Raid.W1.B4.c2"                                iconFile="Data/Multi/w.png"                                                    rotate-z="265"/>
     
     
     <!-- ======================================== SALVATION PASS =============================================================================================================================================================== -->
     <!-- ==================== Slothasor ==================== -->
     <!-- Mushrooms -->
-    <POI MapID="1149" xpos="0208.926" ypos="004.933" zpos="0025.220" GUID="orHk62LZ8EyzraKa0gGXKg==" type="Raid.W2.B1.c1" iconFile="Data/Multi/1.png"/>
-    <POI MapID="1149" xpos="0174.536" ypos="002.414" zpos="-010.016" GUID="FYA1LPmOl0SeX4qUTWMoyw==" type="Raid.W2.B1.c1" iconFile="Data/Multi/2.png"/>
-    <POI MapID="1149" xpos="0192.923" ypos="000.846" zpos="-035.958" GUID="y/MQHT7wCkagUkPZlpFa6A==" type="Raid.W2.B1.c1" iconFile="Data/Multi/3.png"/>
-    <POI MapID="1149" xpos="0224.968" ypos="-00.177" zpos="-013.498" GUID="K4lINKdqcEeKpuQMv9sU1g==" type="Raid.W2.B1.c1" iconFile="Data/Multi/4.png"/>
+    <POI MapID="1149" xpos="0208.926" ypos="004.933" zpos="0025.220" GUID="orHk62LZ8EyzraKa0gGXKg==" type="Raid.W2.B1.c1"           iconFile="Data/Multi/1.png"/>
+    <POI MapID="1149" xpos="0174.536" ypos="002.414" zpos="-010.016" GUID="FYA1LPmOl0SeX4qUTWMoyw==" type="Raid.W2.B1.c1"           iconFile="Data/Multi/2.png"/>
+    <POI MapID="1149" xpos="0192.923" ypos="000.846" zpos="-035.958" GUID="y/MQHT7wCkagUkPZlpFa6A==" type="Raid.W2.B1.c1"           iconFile="Data/Multi/3.png"/>
+    <POI MapID="1149" xpos="0224.968" ypos="-00.177" zpos="-013.498" GUID="K4lINKdqcEeKpuQMv9sU1g==" type="Raid.W2.B1.c1"           iconFile="Data/Multi/4.png"/>
+    <!-- Timer -->
+    <POI MapID="1149" xpos="0208.917" ypos="003.630" zpos="0026.396" GUID="B2NAEktjV0mh7E8YQ8TkgQ==" type="Raid.W2.B1.c2" alpha="2"/>
     <!-- ==================== Trio ==================== -->
     <!-- Beehives -->
-    <POI MapID="1149" xpos="-001.953" ypos="-00.132" zpos="-235.489" GUID="eoxxKScsskiX+qOPk1EYdQ==" type="Raid.W2.B2"    iconFile="Data/Multi/1.png"      iconSize="1.2" rotate-x="185" rotate-y="-3"  rotate-z="115"/>
-    <POI MapID="1149" xpos="-000.567" ypos="-00.619" zpos="-290.812" GUID="uF937Qyrt0qXElHSMUW5nw==" type="Raid.W2.B2"    iconFile="Data/Multi/2.png"      iconSize="1.2" rotate-x="180"                rotate-z="45"/>
-    <POI MapID="1149" xpos="-032.935" ypos="004.176" zpos="-221.024" GUID="yrpc6HFBLUa1dwelKFK/vQ==" type="Raid.W2.B2"    iconFile="Data/Multi/3.png"      iconSize="1.2" rotate-x="162" rotate-z="225"/>
+    <POI MapID="1149" xpos="-001.953" ypos="-00.132" zpos="-235.489" GUID="eoxxKScsskiX+qOPk1EYdQ==" type="Raid.W2.B2"              iconFile="Data/Multi/1.png"     iconSize="1.2" rotate-x="185" rotate-y="-3"  rotate-z="115"/>
+    <POI MapID="1149" xpos="-000.567" ypos="-00.619" zpos="-290.812" GUID="uF937Qyrt0qXElHSMUW5nw==" type="Raid.W2.B2"              iconFile="Data/Multi/2.png"     iconSize="1.2" rotate-x="180"                rotate-z="45"/>
+    <POI MapID="1149" xpos="-032.935" ypos="004.176" zpos="-221.024" GUID="yrpc6HFBLUa1dwelKFK/vQ==" type="Raid.W2.B2"              iconFile="Data/Multi/3.png"     iconSize="1.2" rotate-x="162" rotate-z="225"/>
     <!-- Oils -->
-    <POI MapID="1149" xpos="-030.506" ypos="002.374" zpos="-238.025" GUID="/3CTOpcuskeYgQorlQ/0IQ==" type="Raid.W2.B2"    iconFile="Data/Multi/stack.png"  iconSize="0.5" rotate-x="183" rotate-y="5"/>
+    <POI MapID="1149" xpos="-030.506" ypos="002.374" zpos="-238.025" GUID="/3CTOpcuskeYgQorlQ/0IQ==" type="Raid.W2.B2"              iconFile="Data/Multi/stack.png" iconSize="0.5" rotate-x="183" rotate-y="5"/>
     <!-- Beehive Stack -->
-    <POI MapID="1149" xpos="-016.434" ypos="003.023" zpos="-211.941" GUID="m4f94Wsn90GHWJhUjoVrnw==" type="Raid.W2.B2"    iconFile="Data/Multi/stack.png"  iconSize="0.5" rotate-x="185" rotate-y="-1"/>
+    <POI MapID="1149" xpos="-016.434" ypos="003.023" zpos="-211.941" GUID="m4f94Wsn90GHWJhUjoVrnw==" type="Raid.W2.B2"              iconFile="Data/Multi/stack.png" iconSize="0.5" rotate-x="185" rotate-y="-1"/>
     <!-- ==================== Matthias ==================== -->
+    <!-- Timer -->
+    <POI MapID="1149" xpos="-150.758" ypos="130.023" zpos="0149.853" GUID="if3XON30j0m26dihfDnSEg==" type="Raid.W2.B3.c2" alpha="2"/>
     <!-- Wells -->
-    <POI MapID="1149" xpos="-175.004" ypos="132.375" zpos="0125.376" GUID="pCa90+bN6k2VQkym8Ova6w==" type="Raid.W2.B3.c1" iconFile="Data/Raids/arrow.png"                                               rotate-z="315"/>
-    <POI MapID="1149" xpos="-175.313" ypos="132.375" zpos="0174.125" GUID="C4QcRORmNU+5rMn682ag9g==" type="Raid.W2.B3.c1" iconFile="Data/Raids/circle.png"                                              rotate-z="225"/>
-    <POI MapID="1149" xpos="-126.433" ypos="132.375" zpos="0174.413" GUID="bAdGkZB4kkisSFhyPTn1bw==" type="Raid.W2.B3.c1" iconFile="Data/Raids/heart.png"                                               rotate-z="135"/>
-    <POI MapID="1149" xpos="-126.271" ypos="132.375" zpos="0125.600" GUID="s6fhrG1hNkmW5cJJHZsbJg==" type="Raid.W2.B3.c1" iconFile="Data/Raids/square.png"                                              rotate-z="45"/>
+    <POI MapID="1149" xpos="-175.004" ypos="132.375" zpos="0125.376" GUID="pCa90+bN6k2VQkym8Ova6w==" type="Raid.W2.B3.c3"           iconFile="Data/Raids/arrow.png"                                              rotate-z="315"/>
+    <POI MapID="1149" xpos="-175.313" ypos="132.375" zpos="0174.125" GUID="C4QcRORmNU+5rMn682ag9g==" type="Raid.W2.B3.c3"           iconFile="Data/Raids/circle.png"                                             rotate-z="225"/>
+    <POI MapID="1149" xpos="-126.433" ypos="132.375" zpos="0174.413" GUID="bAdGkZB4kkisSFhyPTn1bw==" type="Raid.W2.B3.c3"           iconFile="Data/Raids/heart.png"                                              rotate-z="135"/>
+    <POI MapID="1149" xpos="-126.271" ypos="132.375" zpos="0125.600" GUID="s6fhrG1hNkmW5cJJHZsbJg==" type="Raid.W2.B3.c3"           iconFile="Data/Raids/square.png"                                             rotate-z="45"/>
     
     
     <!-- ======================================== STRONGHOLD OF THE FAITHFUL =================================================================================================================================================== -->
     <!-- ==================== Keep Construct ==================== -->
     <!-- Green Circles -->
-    <POI MapID="1156" xpos="-097.048" ypos="148.556" zpos="0255.802" GUID="fhaeyOkgC0SweDMNHtlWzg==" type="Raid.W3.B2.c1"/>
-    <POI MapID="1156" xpos="-080.653" ypos="148.556" zpos="0229.251" GUID="1kMFZOLPCkS6JiJdIcz4YQ==" type="Raid.W3.B2.c1"/>
-    <POI MapID="1156" xpos="-113.822" ypos="148.556" zpos="0229.125" GUID="fg81J0pga0SNm4K8SUYn7Q==" type="Raid.W3.B2.c1"/>
+    <POI MapID="1156" xpos="-097.048" ypos="148.556" zpos="0255.802" GUID="fhaeyOkgC0SweDMNHtlWzg==" type="Raid.W3.B2.c2"/>
+    <POI MapID="1156" xpos="-080.653" ypos="148.556" zpos="0229.251" GUID="1kMFZOLPCkS6JiJdIcz4YQ==" type="Raid.W3.B2.c2"/>
+    <POI MapID="1156" xpos="-113.822" ypos="148.556" zpos="0229.125" GUID="fg81J0pga0SNm4K8SUYn7Q==" type="Raid.W3.B2.c2"/>
     <!-- Rifts -->
-    <POI MapID="1156" xpos="-109.351" ypos="148.551" zpos="0251.744" GUID="4MohG8eTBU2qAk2/Ochs5w==" type="Raid.W3.B2.c2"/>
-    <POI MapID="1156" xpos="-115.455" ypos="148.551" zpos="0229.086" GUID="Fn3ecIHlnE6OHuCgXAKqrg==" type="Raid.W3.B2.c2"/>
-    <POI MapID="1156" xpos="-085.363" ypos="148.551" zpos="0252.208" GUID="q1c3bnDY6E2y+VDUJPcDBw==" type="Raid.W3.B2.c2"/>
-    <POI MapID="1156" xpos="-080.025" ypos="148.551" zpos="0229.034" GUID="BHmRO53uKk+MazF3TBR3xw==" type="Raid.W3.B2.c2"/>
-    <POI MapID="1156" xpos="-098.227" ypos="148.551" zpos="0218.485" GUID="rk3s849nHUe9v3JTUBN1rA==" type="Raid.W3.B2.c2"/>
+    <POI MapID="1156" xpos="-109.351" ypos="148.551" zpos="0251.744" GUID="4MohG8eTBU2qAk2/Ochs5w==" type="Raid.W3.B2.c3"/>
+    <POI MapID="1156" xpos="-115.455" ypos="148.551" zpos="0229.086" GUID="Fn3ecIHlnE6OHuCgXAKqrg==" type="Raid.W3.B2.c3"/>
+    <POI MapID="1156" xpos="-085.363" ypos="148.551" zpos="0252.208" GUID="q1c3bnDY6E2y+VDUJPcDBw==" type="Raid.W3.B2.c3"/>
+    <POI MapID="1156" xpos="-080.025" ypos="148.551" zpos="0229.034" GUID="BHmRO53uKk+MazF3TBR3xw==" type="Raid.W3.B2.c3"/>
+    <POI MapID="1156" xpos="-098.227" ypos="148.551" zpos="0218.485" GUID="rk3s849nHUe9v3JTUBN1rA==" type="Raid.W3.B2.c3"/>
     <!-- 1-Orb Pull -->
-    <POI MapID="1156" xpos="-107.558" ypos="148.552" zpos="0249.637" GUID="3jkzHcJ96kaEueETxjSFEQ==" type="Raid.W3.B2.c3"/>
+    <POI MapID="1156" xpos="-107.558" ypos="148.552" zpos="0249.637" GUID="3jkzHcJ96kaEueETxjSFEQ==" type="Raid.W3.B2.c4"/>
     <!-- ==================== Twisted Castle ==================== -->
     <!-- Buttons -->
     <POI MapID="1156" xpos="-027.900" ypos="094.336" zpos="0074.211" GUID="t0VldGp1GESAIL3ssiIKUg==" type="Raid.W3.B3.c2" fadeFar="2000" fadeNear="1500" iconFile="Data/Multi/1.png"/>
@@ -209,24 +232,31 @@
     <!-- ======================================== BASTION OF THE PENITENT ====================================================================================================================================================== -->
     <!-- ==================== Cairn ==================== -->
     <!-- Agony Spots -->
-    <POI MapID="1188" xpos="0369.295" ypos="032.120" zpos="0052.475" GUID="wedtPfCXTEugS91HgQoMkg==" type="Raid.W4.B1" iconFile="Data/Multi/dot.png"                rotate-z="15"/>
-    <POI MapID="1188" xpos="0359.920" ypos="032.120" zpos="0050.043" GUID="sKrUfpjhCkqx1MObpkeN/w==" type="Raid.W4.B1" iconFile="Data/Multi/dot.png"                rotate-z="15"/>
-    <POI MapID="1188" xpos="0361.518" ypos="032.120" zpos="0063.235" GUID="MPL7+6k9ok2ajPAdN+b7yA==" type="Raid.W4.B1" iconFile="Data/Multi/dot.png"                rotate-z="15"/>
+    <POI MapID="1188" xpos="0369.295" ypos="032.120" zpos="0052.475" GUID="wedtPfCXTEugS91HgQoMkg==" type="Raid.W4.B1.c1" iconFile="Data/Multi/dot.png"                rotate-z="15"/>
+    <POI MapID="1188" xpos="0359.920" ypos="032.120" zpos="0050.043" GUID="sKrUfpjhCkqx1MObpkeN/w==" type="Raid.W4.B1.c1" iconFile="Data/Multi/dot.png"                rotate-z="15"/>
+    <POI MapID="1188" xpos="0361.518" ypos="032.120" zpos="0063.235" GUID="MPL7+6k9ok2ajPAdN+b7yA==" type="Raid.W4.B1.c1" iconFile="Data/Multi/dot.png"                rotate-z="15"/>
     <!-- Kiter -->
-    <POI MapID="1188" xpos="0369.301" ypos="032.120" zpos="0034.189" GUID="xXkIzhbDjkC7KmaMBOeoag==" type="Raid.W4.B1" iconFile="Data/Multi/dot.png"                rotate-z="15"/>
-    <!-- ==================== Samarog's Door ==================== -->
-    <POI MapID="1188" xpos="0101.351" ypos="105.300" zpos="0115.941" GUID="AJnnDYZUAEGXGxOx3Zqchg==" type="Raid.W4.C1"                               rotate-x="155" rotate-z="50"/>
-    <POI MapID="1188" xpos="0057.325" ypos="097.480" zpos="0053.245" GUID="qZr3hbBj4U2M8eDHAVUo4Q==" type="Raid.W4.C1"                               rotate-x="120" rotate-z="-25"/>
-    <POI MapID="1188" xpos="0022.747" ypos="111.443" zpos="0103.244" GUID="RvtVRF00I02rBTNZVVAE/Q==" type="Raid.W4.C1"                               rotate-x="120" rotate-z="235"/>
-    <POI MapID="1188" xpos="-011.344" ypos="120.690" zpos="0087.571" GUID="Fr/eTEAoO06UgxlWr6JrWg==" type="Raid.W4.C1"                               rotate-x="160" rotate-z="72"/>
+    <POI MapID="1188" xpos="0369.301" ypos="032.120" zpos="0034.189" GUID="xXkIzhbDjkC7KmaMBOeoag==" type="Raid.W4.B1.c1" iconFile="Data/Multi/dot.png"                rotate-z="15"/>
+    <!-- Timer -->
+    <POI MapID="1188" xpos="0369.760" ypos="032.120" zpos="0060.162" GUID="X61Xv4ZCakilicnR4E+sHA==" type="Raid.W4.B1.c2"/>
+    <!-- ==================== Mursaat Overseer ==================== -->
+    <POI MapID="1188" xpos="0098.396" ypos="104.587" zpos="0101.323" GUID="FNBVzp3IsEeS8TGJz2iJGA==" type="Raid.W4.B2"/>
+    <!-- ==================== Samarog ==================== -->
+    <!-- Door -->
+    <POI MapID="1188" xpos="0101.351" ypos="105.300" zpos="0115.941" GUID="AJnnDYZUAEGXGxOx3Zqchg==" type="Raid.W4.B3.c2"                               rotate-x="155" rotate-z="50"/>
+    <POI MapID="1188" xpos="0057.325" ypos="097.480" zpos="0053.245" GUID="qZr3hbBj4U2M8eDHAVUo4Q==" type="Raid.W4.B3.c2"                               rotate-x="120" rotate-z="-25"/>
+    <POI MapID="1188" xpos="0022.747" ypos="111.443" zpos="0103.244" GUID="RvtVRF00I02rBTNZVVAE/Q==" type="Raid.W4.B3.c2"                               rotate-x="120" rotate-z="235"/>
+    <POI MapID="1188" xpos="-011.344" ypos="120.690" zpos="0087.571" GUID="Fr/eTEAoO06UgxlWr6JrWg==" type="Raid.W4.B3.c2"                               rotate-x="160" rotate-z="72"/>
+    <!-- Timer -->
+    <POI MapED="1188" xpos="-67.681"  ypos="128.011" zpos="82.572"   GUID="eNRKyD30dkSvjHRg8qQYcw==" type="Raid.W4.B3.c3" alpha="2.5"/>
     
     
     <!-- ======================================== HALL OF CHAINS =============================================================================================================================================================== -->
     <!-- ==================== Soulless Horror ==================== -->
-    <POI MapID="1264" xpos="-282.591" ypos="019.162" zpos="0018.416" GUID="O3r698jXbkyiZoxShdmFVA==" type="Raid.W5.B1"    fadeFar="2500" fadeNear="2000" iconFile="Data/Raids/arrow.png"    rotate-z="285"/>
-    <POI MapID="1264" xpos="-266.291" ypos="019.162" zpos="0008.779" GUID="nzYD4KMcF0iMwOfaHhGEYg==" type="Raid.W5.B1"    fadeFar="3000" fadeNear="2500" iconFile="Data/Raids/circle.png"/>
-    <POI MapID="1264" xpos="-256.538" ypos="019.162" zpos="0024.829" GUID="N5t0jBFzaUOaUazzQShtzA==" type="Raid.W5.B1"    fadeFar="3500" fadeNear="3000" iconFile="Data/Raids/heart.png"    rotate-z="105"/>
-    <POI MapID="1264" xpos="-272.783" ypos="019.162" zpos="0034.807" GUID="ayA+SkixgUy8TJEb1q/B/Q==" type="Raid.W5.B1"    fadeFar="3000" fadeNear="2500" iconFile="Data/Raids/square.png"   rotate-z="10"/>
+    <POI MapID="1264" xpos="-268.952" ypos="20.681"   zpos="-15.802" GUID="KkCg/91R+U2uVX0lZM7IdQ==" type="Raid.W5.B1"                 iconFile="Data/Multi/s.png"/>
+	<POI MapID="1264" xpos="-269.824" ypos="20.683"   zpos="59.729"  GUID="2nPxFpzFKkyaEAeMg2fe1A==" type="Raid.W5.B1"                 iconFile="Data/Multi/n.png" rotate-z="180"/>
+	<POI MapID="1264" xpos="-231.84"  ypos="20.682"   zpos="22.065"  GUID="04Fgp4HwD0Gaz7EMzx4kkQ==" type="Raid.W5.B1"                 iconFile="Data/Multi/e.png" rotate-z="90"/>
+	<POI MapID="1264" xpos="-307.302" ypos="20.683"   zpos="21.762"  GUID="OaTwG+Q68EuVapv8voRtJw==" type="Raid.W5.B1"                 iconFile="Data/Multi/w.png" rotate-z="-90"/>
     <!-- ==================== Broken King ==================== -->
     <POI MapID="1264" xpos="0119.032" ypos="110.522" zpos="0227.378" GUID="grZaI9v0MU+2ftEMaR5ZAA==" type="Raid.W5.B3.c1"/>
     <POI MapID="1264" xpos="0103.172" ypos="109.405" zpos="0221.664" GUID="V0pqQq3PXU2g511ppq7GzQ==" type="Raid.W5.B3.c1"/>
@@ -241,14 +271,34 @@
     <POI MapID="1264" xpos="0364.569" ypos="097.308" zpos="0024.818" GUID="bVntJ42H6keMS4NQ4QrYDQ==" type="Raid.W5.B3.c2"/>
     <POI MapID="1264" xpos="0384.978" ypos="097.308" zpos="0020.738" GUID="jDkcSZokJUSzaTgg/4Bk9g==" type="Raid.W5.B3.c2"/>
     <!-- ==================== Dhuum  ==================== -->
-    <!-- Reapers -->
-    <POI MapID="1264" xpos="0429.189" ypos="156.367" zpos="0030.746" GUID="7lAXpIckh0etEDT7qkgtIg==" type="Raid.W5.B4.c1"                                iconFile="Data/Raids/arrow.png"    rotate-z="110"/>
-    <POI MapID="1264" xpos="0427.832" ypos="156.367" zpos="0001.910" GUID="Iqrpk9JOtkGC6V8iv8rcKA==" type="Raid.W5.B4.c1"                                iconFile="Data/Raids/circle.png"   rotate-z="60"/>
-    <POI MapID="1264" xpos="0404.769" ypos="156.364" zpos="-014.699" GUID="XM2/dG4/LkuWpoTNZcCOlg==" type="Raid.W5.B4.c1"                                iconFile="Data/Raids/heart.png"    rotate-z="10"/>
-    <POI MapID="1264" xpos="0377.723" ypos="156.361" zpos="-006.419" GUID="lTh96zuv702S+mtGJOWb5Q==" type="Raid.W5.B4.c1"                                iconFile="Data/Raids/square.png"   rotate-z="-45"/>
-    <POI MapID="1264" xpos="0365.995" ypos="156.372" zpos="0019.329" GUID="YzhiOdvBf0y1GNebTAkfmw==" type="Raid.W5.B4.c1"                                iconFile="Data/Raids/star.png"     rotate-z="270"/>
-    <POI MapID="1264" xpos="0379.073" ypos="156.360" zpos="0044.817" GUID="OpI4IpyEqUeS5Zsfd9KPyg==" type="Raid.W5.B4.c1"                                iconFile="Data/Raids/swirl.png"    rotate-z="200"/>
-    <POI MapID="1264" xpos="0407.780" ypos="156.364" zpos="0049.950" GUID="Im4Wm3WM5kCKHI1D/ov4FA==" type="Raid.W5.B4.c1"                                iconFile="Data/Raids/triangle.png" rotate-z="165"/>
+    <!-- Green 1 -->
+    <POI MapID="1264" xpos="0429.189" ypos="158.367" zpos="0030.746" GUID="7lAXpIckh0etEDT7qkgtIg==" type="Raid.W5.B4.c1.g1"           iconFile="Data/Raids/W5/1.png"/>
+    <POI MapID="1264" xpos="0427.832" ypos="158.367" zpos="0001.910" GUID="Iqrpk9JOtkGC6V8iv8rcKA==" type="Raid.W5.B4.c1.g1"           iconFile="Data/Raids/W5/6.png"/>
+    <POI MapID="1264" xpos="0404.769" ypos="158.364" zpos="-014.699" GUID="XM2/dG4/LkuWpoTNZcCOlg==" type="Raid.W5.B4.c1.g1"           iconFile="Data/Raids/W5/4.png"/>
+    <POI MapID="1264" xpos="0377.723" ypos="158.361" zpos="-006.419" GUID="lTh96zuv702S+mtGJOWb5Q==" type="Raid.W5.B4.c1.g1"           iconFile="Data/Raids/W5/2.png"/>
+    <POI MapID="1264" xpos="0365.995" ypos="158.372" zpos="0019.329" GUID="YzhiOdvBf0y1GNebTAkfmw==" type="Raid.W5.B4.c1.g1"           iconFile="Data/Raids/W5/7.png"/>
+    <POI MapID="1264" xpos="0379.073" ypos="158.360" zpos="0044.817" GUID="OpI4IpyEqUeS5Zsfd9KPyg==" type="Raid.W5.B4.c1.g1"           iconFile="Data/Raids/W5/5.png"/>
+    <POI MapID="1264" xpos="0407.780" ypos="158.364" zpos="0049.950" GUID="Im4Wm3WM5kCKHI1D/ov4FA==" type="Raid.W5.B4.c1.g1"           iconFile="Data/Raids/W5/3.png"/>
+    <!-- Green 2 -->
+    <POI MapID="1264" xpos="0429.189" ypos="158.367" zpos="0030.746" GUID="7lAXpIckh0etEDT7qkgtIg==" type="Raid.W5.B4.c1.g2"           iconFile="Data/Raids/W5/3.png"/>
+    <POI MapID="1264" xpos="0427.832" ypos="158.367" zpos="0001.910" GUID="Iqrpk9JOtkGC6V8iv8rcKA==" type="Raid.W5.B4.c1.g2"           iconFile="Data/Raids/W5/1.png"/>
+    <POI MapID="1264" xpos="0404.769" ypos="158.364" zpos="-014.699" GUID="XM2/dG4/LkuWpoTNZcCOlg==" type="Raid.W5.B4.c1.g2"           iconFile="Data/Raids/W5/6.png"/>
+    <POI MapID="1264" xpos="0377.723" ypos="158.361" zpos="-006.419" GUID="lTh96zuv702S+mtGJOWb5Q==" type="Raid.W5.B4.c1.g2"           iconFile="Data/Raids/W5/4.png"/>
+    <POI MapID="1264" xpos="0365.995" ypos="158.372" zpos="0019.329" GUID="YzhiOdvBf0y1GNebTAkfmw==" type="Raid.W5.B4.c1.g2"           iconFile="Data/Raids/W5/2.png"/>
+    <POI MapID="1264" xpos="0379.073" ypos="158.360" zpos="0044.817" GUID="OpI4IpyEqUeS5Zsfd9KPyg==" type="Raid.W5.B4.c1.g2"           iconFile="Data/Raids/W5/7.png"/>
+    <POI MapID="1264" xpos="0407.780" ypos="158.364" zpos="0049.950" GUID="Im4Wm3WM5kCKHI1D/ov4FA==" type="Raid.W5.B4.c1.g2"           iconFile="Data/Raids/W5/5.png"/>
+    <!-- Green 3 -->
+    <POI MapID="1264" xpos="0429.189" ypos="158.367" zpos="0030.746" GUID="7lAXpIckh0etEDT7qkgtIg==" type="Raid.W5.B4.c1.g3"           iconFile="Data/Raids/W5/5.png"/>
+    <POI MapID="1264" xpos="0427.832" ypos="158.367" zpos="0001.910" GUID="Iqrpk9JOtkGC6V8iv8rcKA==" type="Raid.W5.B4.c1.g3"           iconFile="Data/Raids/W5/3.png"/>
+    <POI MapID="1264" xpos="0404.769" ypos="158.364" zpos="-014.699" GUID="XM2/dG4/LkuWpoTNZcCOlg==" type="Raid.W5.B4.c1.g3"           iconFile="Data/Raids/W5/1.png"/>
+    <POI MapID="1264" xpos="0377.723" ypos="158.361" zpos="-006.419" GUID="lTh96zuv702S+mtGJOWb5Q==" type="Raid.W5.B4.c1.g3"           iconFile="Data/Raids/W5/6.png"/>
+    <POI MapID="1264" xpos="0365.995" ypos="158.372" zpos="0019.329" GUID="YzhiOdvBf0y1GNebTAkfmw==" type="Raid.W5.B4.c1.g3"           iconFile="Data/Raids/W5/4.png"/>
+    <POI MapID="1264" xpos="0379.073" ypos="158.360" zpos="0044.817" GUID="OpI4IpyEqUeS5Zsfd9KPyg==" type="Raid.W5.B4.c1.g3"           iconFile="Data/Raids/W5/2.png"/>
+    <POI MapID="1264" xpos="0407.780" ypos="158.364" zpos="0049.950" GUID="Im4Wm3WM5kCKHI1D/ov4FA==" type="Raid.W5.B4.c1.g3"           iconFile="Data/Raids/W5/7.png"/>
+    <!-- Timer (Left) -->
+    <POI MapID="1264" xpos="0377.774" ypos="156.360" zpos="-006.485" GUID="EtK0p1Uk0UeKo9XTwOgzEw==" type="Raid.W5.B4.c3"    alpha="2"/>
+    <!-- Timer (Right)
+    <POI MapID="1264" xpos="379.073"  ypos="156.360" zpos="44.817"   GUID="EtK0p1Uk0UeKo9XTzOgzEw==" type="Raid.W5.B4.c3"    alpha="2"/> -->
     
     
     <!-- ======================================== MYTHWRIGHT GAMBIT ============================================================================================================================================================ -->
@@ -292,79 +342,51 @@
     <!-- ======================================== THE KEY OF AHDASHIM ========================================================================================================================================================== -->
     <!-- ==================== Cardinal Adina ==================== -->
     <!-- Directions -->
-    <POI MapID="1323" xpos="378.580" ypos="07.754" zpos="-007.834" GUID="XjkNdote70a+BUidfQ7/Aw==" type="Raid.W7.B2.c1" iconFile="Data/Multi/n.png" rotate-z="180"/>
-    <POI MapID="1323" xpos="378.767" ypos="07.752" zpos="-066.733" GUID="QvNEXKwrd0OBwpasrWvG5Q==" type="Raid.W7.B2.c1" iconFile="Data/Multi/s.png"/>
+    <POI MapID="1323" xpos="378.580" ypos="07.754" zpos="-007.834" GUID="XjkNdote70a+BUidfQ7/Aw==" type="Raid.W7.B1.c2" iconFile="Data/Multi/n.png" rotate-z="180"/>
+    <POI MapID="1323" xpos="378.767" ypos="07.752" zpos="-066.733" GUID="QvNEXKwrd0OBwpasrWvG5Q==" type="Raid.W7.B1.c2" iconFile="Data/Multi/s.png"/>
     <!-- Pillars -->
-    <POI MapID="1323" xpos="378.634" ypos="06.157" zpos="-026.001" GUID="+qDcWauW20a8Q8KpfSXdDA==" type="Raid.W7.B2.c2"/>
-    <POI MapID="1323" xpos="378.592" ypos="06.153" zpos="-048.800" GUID="/ZrMwfAtSkWhLenh/nA5Uw==" type="Raid.W7.B2.c2"/>
-    <POI MapID="1323" xpos="383.636" ypos="06.152" zpos="-051.680" GUID="mgeK+szOhk6vLhrhm1oSrQ==" type="Raid.W7.B2.c2"/>
-    <POI MapID="1323" xpos="388.349" ypos="06.153" zpos="-037.340" GUID="9g1K9lXLoU2hT0VMVx/Stg==" type="Raid.W7.B2.c2"/>
-    <POI MapID="1323" xpos="368.997" ypos="06.152" zpos="-037.385" GUID="WtRHIgyaFkWPCSaiRUzoHw==" type="Raid.W7.B2.c2"/>
+    <POI MapID="1323" xpos="378.634" ypos="06.157" zpos="-026.001" GUID="+qDcWauW20a8Q8KpfSXdDA==" type="Raid.W7.B1.c2"/>
+    <POI MapID="1323" xpos="378.592" ypos="06.153" zpos="-048.800" GUID="/ZrMwfAtSkWhLenh/nA5Uw==" type="Raid.W7.B1.c2"/>
+    <POI MapID="1323" xpos="383.636" ypos="06.152" zpos="-051.680" GUID="mgeK+szOhk6vLhrhm1oSrQ==" type="Raid.W7.B1.c2"/>
+    <POI MapID="1323" xpos="388.349" ypos="06.153" zpos="-037.340" GUID="9g1K9lXLoU2hT0VMVx/Stg==" type="Raid.W7.B1.c2"/>
+    <POI MapID="1323" xpos="368.997" ypos="06.152" zpos="-037.385" GUID="WtRHIgyaFkWPCSaiRUzoHw==" type="Raid.W7.B1.c2"/>
     <!-- ==================== Qadim the Peerless ==================== -->
-    <!-- Pylons -->
-    <POI MapID="1323" xpos="041.543" ypos="16.813" zpos="0294.356" GUID="0OXp2ufTbU6/fEo+UcwOMA==" type="Raid.W7.B3.c1" iconFile="Data/Multi/1.png"/>
-    <POI MapID="1323" xpos="008.317" ypos="16.812" zpos="0236.796" GUID="UPNrnI78QEKYECwurS+1KQ==" type="Raid.W7.B3.c1" iconFile="Data/Multi/2.png"/>
-    <POI MapID="1323" xpos="074.861" ypos="16.813" zpos="0236.700" GUID="PSR2ZpIrIUKHZQKqcJwZJQ==" type="Raid.W7.B3.c1" iconFile="Data/Multi/3.png"/>
     <!-- Fire Placements -->
-    <POI MapID="1323" xpos="013.225" ypos="15.212" zpos="0261.338" GUID="X5Uu+2XzIkeW25s5IobysA==" type="Raid.W7.B3.c2"/>
-    <POI MapID="1323" xpos="031.330" ypos="15.212" zpos="0229.034" GUID="gwUZcxvlEUWtsfyLn9UK4A==" type="Raid.W7.B3.c2"/>
-    <POI MapID="1323" xpos="051.537" ypos="15.212" zpos="0229.197" GUID="s0/sh5qLQEqE9Zv5yrNieA==" type="Raid.W7.B3.c2"/>
-    <POI MapID="1323" xpos="069.551" ypos="15.212" zpos="0260.601" GUID="XCl9c1J/wU2dD7witzAqAA==" type="Raid.W7.B3.c2"/>
-    <POI MapID="1323" xpos="059.504" ypos="15.212" zpos="0277.788" GUID="a90szDLj1EO59iM+urCCLA==" type="Raid.W7.B3.c2"/>
-    <POI MapID="1323" xpos="023.568" ypos="15.212" zpos="0278.362" GUID="gZJ5YPQBvUaAMPTQWK4iiw==" type="Raid.W7.B3.c2"/>
-    
-    
-    <!-- ======================================== CHESTS ======================================================================================================================================================================= -->
-    <!-- ==================== Spirit Vale's Chests ==================== -->
-    <POI MapID="1062" xpos="-126.154" ypos="028.506" zpos="-223.073" GUID="cjZXgMou5USqfnzLndQviA==" type="Raid.W1.Ch"/>
-    <POI MapID="1062" xpos="-063.604" ypos="053.378" zpos="-154.726" GUID="GXd06oAwjEmgK3dUui+DCg==" type="Raid.W1.Ch"/>
-    <POI MapID="1062" xpos="-085.536" ypos="073.136" zpos="-208.998" GUID="rP/zhuCv/EGs7J27tLVPzQ==" type="Raid.W1.Ch"/>
-    <POI MapID="1062" xpos="-288.772" ypos="087.124" zpos="0108.459" GUID="AhDsYRdBB0KYX4qlE4AOVQ==" type="Raid.W1.Ch"/>
-    <!-- ==================== Salvation Pass's Chests ==================== -->
-    <POI MapID="1149" xpos="0210.660" ypos="-02.364" zpos="-054.405" GUID="iRCrHJxb20O5LMcM2jLBqQ==" type="Raid.W2.Ch"/>
-    <POI MapID="1149" xpos="0283.288" ypos="075.502" zpos="-365.385" GUID="4gvlQ1IY4kKni2cWKCtTRA==" type="Raid.W2.Ch"/>
-    <POI MapID="1149" xpos="0003.740" ypos="084.782" zpos="-120.950" GUID="GrIzR9IAjkmMVvwCadAHgw==" type="Raid.W2.Ch"/>
-    <POI MapID="1149" xpos="-095.842" ypos="106.800" zpos="0061.237" GUID="M9ogYIfe2E2O74+ZDtMKYw==" type="Raid.W2.Ch"/>
-    <!-- ==================== Stronghold of the Faithful's Chests ==================== -->
-    <POI MapID="1156" xpos="-144.691" ypos="195.506" zpos="-016.263" GUID="5E99G0iZ00SSWpHKs2cVLw==" type="Raid.W3.Ch"/>
-    <POI MapID="1156" xpos="-075.941" ypos="193.239" zpos="0011.751" GUID="IVX/ZwUu8U6W0MnnZjOO1A==" type="Raid.W3.Ch"/>
-    <POI MapID="1156" xpos="-141.051" ypos="199.192" zpos="0116.734" GUID="O+m8BVoxv0ywAiGRZvzu1A==" type="Raid.W3.Ch"/>
-    <!-- ==================== Bastion of the Penitent's Chests ==================== -->
-    <POI MapID="1188" xpos="0255.450" ypos="001.812" zpos="-008.769" GUID="kSb9nf2xkkCgf3ec6shoOg==" type="Raid.W4.Ch"/>
-    <POI MapID="1188" xpos="0012.754" ypos="104.681" zpos="0157.706" GUID="tFTlK9GZLkmXHutWAiPLGA==" type="Raid.W4.Ch"/>
-    <POI MapID="1188" xpos="-055.900" ypos="134.096" zpos="0013.589" GUID="nMsOvdFBT0u3x5pC/BwR9Q==" type="Raid.W4.Ch"/>
-    <POI MapID="1188" xpos="-265.259" ypos="083.430" zpos="-009.366" GUID="ep/PkTf+Okq5affn73w/lg==" type="Raid.W4.Ch"/>
-    <!-- ==================== Hall of Chain's Chests ==================== -->
-    <POI MapID="1264" xpos="-339.401" ypos="036.625" zpos="0181.413" GUID="ljo0u+dqp0WFZkoJ8DDLFw==" type="Raid.W5.Ch"/>
-    <POI MapID="1264" xpos="0225.671" ypos="021.862" zpos="-052.562" GUID="zXy+4KUY7EOnBCv0jOsSEA==" type="Raid.W5.Ch"/>
-    <POI MapID="1264" xpos="0470.616" ypos="163.093" zpos="0015.220" GUID="D9EyjAP7VkqisFpFTLzb7Q==" type="Raid.W5.Ch"/>
-    <!-- ==================== Mythwright Gambit's Chests ==================== -->
-    <POI MapID="1303" xpos="-254.967" ypos="148.280" zpos="-481.495" GUID="eVxGWPyLa0eUySUE1YoM3Q==" type="Raid.W6.Ch"/>
-    <POI MapID="1303" xpos="-032.101" ypos="120.490" zpos="0317.837" GUID="VMf89b+HhUiybPCQz2TuuA==" type="Raid.W6.Ch"/>
+    <POI MapID="1323" xpos="013.225" ypos="15.212" zpos="0261.338" GUID="X5Uu+2XzIkeW25s5IobysA==" type="Raid.W7.B3.c1"/>
+    <POI MapID="1323" xpos="031.330" ypos="15.212" zpos="0229.034" GUID="gwUZcxvlEUWtsfyLn9UK4A==" type="Raid.W7.B3.c1"/>
+    <POI MapID="1323" xpos="051.537" ypos="15.212" zpos="0229.197" GUID="s0/sh5qLQEqE9Zv5yrNieA==" type="Raid.W7.B3.c1"/>
+    <POI MapID="1323" xpos="069.551" ypos="15.212" zpos="0260.601" GUID="XCl9c1J/wU2dD7witzAqAA==" type="Raid.W7.B3.c1"/>
+    <POI MapID="1323" xpos="059.504" ypos="15.212" zpos="0277.788" GUID="a90szDLj1EO59iM+urCCLA==" type="Raid.W7.B3.c1"/>
+    <POI MapID="1323" xpos="023.568" ypos="15.212" zpos="0278.362" GUID="gZJ5YPQBvUaAMPTQWK4iiw==" type="Raid.W7.B3.c1"/>
+    <!-- Pylons -->
+    <POI MapID="1323" xpos="041.543" ypos="16.813" zpos="0294.356" GUID="0OXp2ufTbU6/fEo+UcwOMA==" type="Raid.W7.B3.c2" iconFile="Data/Multi/1.png"/>
+    <POI MapID="1323" xpos="008.317" ypos="16.812" zpos="0236.796" GUID="UPNrnI78QEKYECwurS+1KQ==" type="Raid.W7.B3.c2" iconFile="Data/Multi/2.png"/>
+    <POI MapID="1323" xpos="074.861" ypos="16.813" zpos="0236.700" GUID="PSR2ZpIrIUKHZQKqcJwZJQ==" type="Raid.W7.B3.c2" iconFile="Data/Multi/3.png"/>
     
     
     <!-- ======================================== TRAILS ======================================================================================================================================================================= -->
     <!-- ==================== Vale Guardian's Raid Boundary ==================== -->
     <Trail trailData="Data/Raids/W1/vgBound.trl"         texture="Data/Raids/W1/greentrail.png" animSpeed="0" alpha="1"    type="Raid.W1.B1"/>
     <!-- ==================== Spirit Run's Trigger Lines ==================== -->
-    <Trail trailData="Data/Raids/W1/SR_TriggerLines.trl" texture="Data/Raids/W1/greentrail.png" animSpeed="0" alpha="0.75" type="Raid.W1.B2.c2"/>
+    <Trail trailData="Data/Raids/W1/SR_TriggerLines.trl" texture="Data/Raids/W1/greentrail.png" animSpeed="0" alpha="0.75" type="Raid.W1.B2.c2" profession="mesmer"/>
+    <Trail trailData="Data/Raids/W1/SR_TriggerLines.trl" texture="Data/Raids/W1/greentrail.png" animSpeed="0" alpha="0.75" type="Raid.W1.B2.c2" profession="thief"/>
     <!-- ==================== Gorseval's Raid Boundary ==================== -->
-    <Trail trailData="Data/Raids/W1/gorsBound.trl"       texture="Data/Raids/W1/greentrail.png" animSpeed="0" alpha="0.75" type="Raid.W1.B3.c2"/>
+    <Trail trailData="Data/Raids/W1/gorsBound.trl"       texture="Data/Raids/W1/greentrail.png" animSpeed="0" alpha="0.75" type="Raid.W1.B3.c1"/>
     <!-- ==================== Sabetha's Raid Boundary ==================== -->
-    <Trail trailData="Data/Raids/W1/sabBound.trl"        texture="Data/Raids/W1/greentrail.png" animSpeed="0" alpha="0.75" type="Raid.W1.B4.c2"/>
+    <Trail trailData="Data/Raids/W1/sabBound.trl"        texture="Data/Raids/W1/greentrail.png" animSpeed="0" alpha="0.75" type="Raid.W1.B4.c1"/>
     <!-- ==================== Matthias' Raid Boundary ==================== -->
-    <Trail trailData="Data/Raids/W2/mattBound.trl"            texture="Data/Raids/W3/whitetrail.png" animSpeed="0" alpha="0.75" type="Raid.W2.B3.c3"/>
+    <Trail trailData="Data/Raids/W2/mattBound.trl"       texture="Data/Raids/W3/whitetrail.png" animSpeed="0" alpha="0.75" type="Raid.W2.B3.c1"/>
     <!-- ==================== Keep Construct's Raid Boundary -->
-    <Trail trailData="Data/Raids/W3/KC.trl"              texture="Data/Raids/W3/whitetrail.png" animSpeed="0" alpha="0.65" type="Raid.W3.B2.c4"/>
+    <Trail trailData="Data/Raids/W3/KC.trl"              texture="Data/Raids/W3/whitetrail.png" animSpeed="0" alpha="0.65" type="Raid.W3.B2.c1"/>
     <!-- ==================== Twisted Castle's 1st Button Skip ==================== -->
     <Trail trailData="Data/Raids/W3/TwistedCastle.trl"   texture="Data/Raids/W3/whitetrail.png" animSpeed="2" alpha="1"    type="Raid.W3.B3.c1"/>
     <!-- ==================== Samarog's Raid Boundary ==================== -->
-    <Trail trailData="Data/Raids/W4/Samarog.trl"         texture="Data/Raids/W3/whitetrail.png" animSpeed="0" alpha="0.75" type="Raid.W4.B3"/>
+    <Trail trailData="Data/Raids/W4/Samarog.trl"         texture="Data/Raids/W3/whitetrail.png" animSpeed="0" alpha="1"    type="Raid.W4.B3.c1"/>
     <!-- ==================== Dhuum's Death AoE ==================== -->
     <Trail trailData="Data/Raids/W5/circle_of_death.trl" texture="Data/Raids/W5/Death.png"      animSpeed="-2" alpha="1"   type="Raid.W5.B4.c3"/>
     <!-- ==================== Conjured Amalgamate's Raid Boundary ==================== -->
-    <Trail trailData="Data/Raids/W6/CA.trl"              texture="Data/Raids/W3/whitetrail.png" animSpeed="0" alpha="0.75" type="Raid.W6.B1.c2"/>
+    <Trail trailData="Data/Raids/W6/CA.trl"              texture="Data/Raids/W3/whitetrail.png" animSpeed="0" alpha="0.75" type="Raid.W6.B1.c1"/>
     <!-- ==================== Cardinal Sabir's Raid Boundary ==================== -->
-    <Trail trailData="Data/Raids/W7/Sabir.trl"           texture="Data/Raids/W3/whitetrail.png" animSpeed="0" alpha="0.75" type="Raid.W7.B1"/>
+    <Trail trailData="Data/Raids/W7/Sabir.trl"           texture="Data/Raids/W3/whitetrail.png" animSpeed="0" alpha="0.75" type="Raid.W7.B2"/>
   </POIs>
 </OverlayData>


### PR DESCRIPTION
This PR comes with some deletions and additions.

### Deletions:
- Removed Chests until improved support from Blish comes out for them.
- Removed Speed/Adrenal Mushrooms until improved support from Blish comes out for them.

### Additions:
- Re-added timers due to the removal of taco markers.
- Added support for all four spirit markers in Gorseval.
- Added improved support for Dhuum greens.

### Others:
- Lots of subcategory reorganization (to be alphabetical for all but one instance).
- Changed Spirit Run's Skip to only support Mesmer and Thief (the only portal classes).
- Moved Samarog's Door markers into the Samarog category.