### PR TITLE
Miscellaneous Stuff

### DIFF
--- a/Blish HUD/Fractals.xml
+++ b/Blish HUD/Fractals.xml
@@ -3,21 +3,30 @@
 <!-- ======================================================================================================================= -->
 <OverlayData>
   <MarkerCategory       name="FOTM" DisplayName="Fractals of the Mists">
+  
     <MarkerCategory     name="Ti"   DisplayName="Hero's Marker Pack" IsSeparator="1"/>
+    
     <MarkerCategory     name="AB"   DisplayName="Aetherblade">
-      <MarkerCategory   name="c1"   DisplayName="Skip"                                    fadeFar="850"  fadeNear="600"/>
+      <MarkerCategory   name="c1"   DisplayName="Electric Skip"                           fadeFar="850"  fadeNear="600"/>
     </MarkerCategory>
+    
     <MarkerCategory     name="AR"   DisplayName="Aquatic Ruins"/>
+    
     <MarkerCategory     name="CMT"  DisplayName="Captain Mai Trin"/>
+    
     <MarkerCategory     name="CI"   DisplayName="Chaos Isles"/>
+    
     <MarkerCategory     name="CS"   DisplayName="Cliffside">
       <MarkerCategory   name="c1"   DisplayName="Speed Skip"/>
       <MarkerCategory   name="c2"   DisplayName="Wind Skip"                               fadeFar="1250" fadeNear="1000"/>
       <MarkerCategory   name="c3"   DisplayName="Chest Speed Skip"                                                                                                      rotate-x="180"/>
       <MarkerCategory   name="c4"   DisplayName="Boss Skip"/>
     </MarkerCategory>
+    
     <MarkerCategory     name="DS"   DisplayName="Deepstone"/>
+    
     <MarkerCategory     name="MO"   DisplayName="Mistlock Observatory"                                                                                  iconSize="0.2"/>
+    
     <MarkerCategory     name="MB"   DisplayName="Molten Boss">
       <MarkerCategory   name="c1"   DisplayName="Tele Skip"/>
       <MarkerCategory   name="c2"   DisplayName="Teamwork Skip">
@@ -26,25 +35,32 @@
         <MarkerCategory name="sc3"  DisplayName="Door Skip"/>
       </MarkerCategory>
     </MarkerCategory>
+    
     <MarkerCategory     name="MF"   DisplayName="Molten Furnace">
       <MarkerCategory   name="c2"   DisplayName="Dredge Spawns"                           fadeFar="1500" fadeNear="1000" iconFile="Data/Multi/dot.png"  iconSize="0.35" rotate-x="180"/>
     </MarkerCategory>
+    
     <MarkerCategory     name="NM"   DisplayName="Nightmare">
       <MarkerCategory   name="c1"   DisplayName="Knight Spawns"                           fadeFar="3500" fadeNear="3000"                                iconSize="0.75" rotate-x="180"/>
       <MarkerCategory   name="c2"   DisplayName="Siax Directions"                         fadeFar="2250" fadeNear="2000"                                iconSize="1"    rotate-x="90"/>
       <MarkerCategory   name="c3"   DisplayName="Ensolyss' Orbs"                          fadeFar="2500" fadeNear="2000" iconFile="Data/Fracs/ball.png" iconSize="0.5"  rotate-x="180"/>
       <MarkerCategory   name="c4"   DisplayName="North"                                   fadeFar="2500" fadeNear="2000" iconFile="Data/Multi/n.png"    iconSize="1"    rotate-x="90"  rotate-z="180"/>
     </MarkerCategory>
+    
     <MarkerCategory     name="ShO"  DisplayName="Shattered Observatory">
       <MarkerCategory   name="c1"   DisplayName="Virastra Skip"                                                                                         iconSize="0.5"/>
       <MarkerCategory   name="c2"   DisplayName="Arkk Directions"                         fadeFar="3000" fadeNear="2750"                                                rotate-x="90"/>
     </MarkerCategory>
+    
     <MarkerCategory     name="SR"   DisplayName="Siren's Reef"                            fadeFar="3250" fadeNear="3000" iconFile="Data/Fracs/SR.png"   iconSize="0.75" rotate-x="175"/>
+    
     <MarkerCategory     name="SB"   DisplayName="Snowblind"/>
+    
     <MarkerCategory     name="SoO"  DisplayName="Solid Ocean">
       <MarkerCategory   name="c1"   DisplayName="Path Skip"/>
       <MarkerCategory   name="c2"   DisplayName="Jade Colossus Spawns"                    fadeFar="4000" fadeNear="3500"                                iconSize="1"    rotate-x="180"/>
     </MarkerCategory>
+    
     <MarkerCategory     name="SL"   DisplayName="Swampland">
       <MarkerCategory   name="c1"   DisplayName="Swampland Traps"       defaultToggle="0" fadeFar="1100" fadeNear="850"                                 iconSize="0.6"                                bounce-duration="0.5" bounce-distance="28" bounce-height="1" bounce-when="inzone">
         <MarkerCategory name="t1"   DisplayName="Top Left (Skelk)"                                                       iconFile="Data/Fracs/Trip.png"/>
@@ -57,26 +73,30 @@
         <MarkerCategory name="t8"   DisplayName="Bottom Right (Spiders)"/>
       </MarkerCategory>
     </MarkerCategory>
+    
     <MarkerCategory     name="TR"   DisplayName="Thaumanova Reactor">
       <MarkerCategory   name="c1"   DisplayName="Maze"                                    fadeFar="3000" fadeNear="2750"                                iconSize="0.75"/>
       <MarkerCategory   name="c2"   DisplayName="Subject 6 Portal"                                                                                      iconSize="0.75" rotate-x="180"/>
     </MarkerCategory>
+    
     <MarkerCategory     name="TO"   DisplayName="Twilight Oasis"                          fadeFar="1000" fadeNear="750"                                 iconSize="0.5"/>
+    
     <MarkerCategory     name="UC"   DisplayName="Uncategorized">
+      <MarkerCategory   name="c0"   DisplayName="Skip to Old Tom"                         fadeFar="1350" fadeNear="1100"                                iconSize="0.5"  rotate-x="180" rotate-z="-98"/>
       <MarkerCategory   name="c1"   DisplayName="Harpy JP Skip"                           fadeFar="1000" fadeNear="750"/>
       <MarkerCategory   name="c2"   DisplayName="Harpy Leap Skip"                         fadeFar="1000" fadeNear="750"/>
     </MarkerCategory>
+    
     <MarkerCategory     name="UF"   DisplayName="Underground Facility">
       <MarkerCategory   name="c1"   DisplayName="Button Skip"                             fadeFar="1250" fadeNear="1000"/>
       <MarkerCategory   name="c2"   DisplayName="Bucket Boundaries"                       fadeFar="1250" fadeNear="1000"/>
     </MarkerCategory>
+    
     <MarkerCategory     name="UB"   DisplayName="Urban Battleground">
       <MarkerCategory   name="c1"   DisplayName="Burning Oil Boundary"/>
-      <MarkerCategory   name="c2"   DisplayName="Barricade Skip">
-        <MarkerCategory name="sc1"  DisplayName="Variant 1"/>
-        <MarkerCategory name="sc2"  DisplayName="Variant 2"/>
-      </MarkerCategory>
+      <MarkerCategory   name="c2"   DisplayName="Barricade Skip"/>
     </MarkerCategory>
+    
     <MarkerCategory     name="Vo"   DisplayName="Volcanic">
       <MarkerCategory   name="c1"   DisplayName="Portal"                                                                                                iconSize="0.35"/>
       <MarkerCategory   name="c2"   DisplayName="Cliff Fall"/>
@@ -86,6 +106,7 @@
   <POIs>
     <!-- ======================================== AETHERBLADE ================================================================================================================================================================== -->
     <POI MapID="956" xpos="-021.480" ypos="07.351" zpos="096.879" GUID="TeExJPcqu0qaos1t9NVy5Q==" type="FOTM.AB.c1" iconFile="Data/Fracs/skipEle2.png" iconSize="0.5" profession="elementalist" rotate-x="0.01" rotate-z="-75"/>
+    <POI MapID="956" xpos="-021.480" ypos="07.351" zpos="096.879" GUID="TeExJPcqu0qaos1t9NVy5Q==" type="FOTM.AB.c1" iconFile="Data/Fracs/skipGrd2.png" iconSize="0.5" profession="guardian"     rotate-x="0.01" rotate-z="-75"/>
     <POI MapID="956" xpos="-021.480" ypos="07.351" zpos="096.879" GUID="TeExJPcqu0qaos1t9NVy5Q==" type="FOTM.AB.c1" iconFile="Data/Fracs/skipMes2.png" iconSize="0.5" profession="mesmer"       rotate-x="0.01" rotate-z="-75"/>
     <POI MapID="956" xpos="-021.480" ypos="07.351" zpos="096.879" GUID="TeExJPcqu0qaos1t9NVy5Q==" type="FOTM.AB.c1" iconFile="Data/Fracs/skipNec2.png" iconSize="0.5" profession="necromancer"  rotate-x="0.01" rotate-z="-75"/>
     <POI MapID="956" xpos="-021.480" ypos="07.351" zpos="096.879" GUID="TeExJPcqu0qaos1t9NVy5Q==" type="FOTM.AB.c1" iconFile="Data/Fracs/skipThf2.png" iconSize="0.5" profession="thief"        rotate-x="0.01" rotate-z="-75"/>
@@ -119,6 +140,7 @@
     <POI MapID="952" xpos="64.284" ypos="591.430" zpos="096.785" GUID="0rMXPgdqGk6zn89nFpCYKw==" type="FOTM.CS.c2"                                iconFile="Data/Fracs/WMPDenter.png"   iconSize="0.5"  profession="engineer"     rotate-x="180"                rotate-z="180"/>
     <POI MapID="952" xpos="66.268" ypos="629.205" zpos="106.401" GUID="YmFq1+jrZEOTJzw1E4bRuQ==" type="FOTM.CS.c2"                                iconFile="Data/Fracs/WMPDexit.png"    iconSize="0.5"  profession="engineer"     rotate-x="180"/>
     <POI MapID="952" xpos="64.284" ypos="591.430" zpos="096.785" GUID="0rMXPgdqGk6zn89nFpCYKw==" type="FOTM.CS.c2"                                iconFile="Data/Fracs/WMPDenter.png"   iconSize="0.5"  profession="guardian"     rotate-x="180"                rotate-z="180"/>
+    <POI MapID="952" xpos="58.289" ypos="612.994" zpos="103.089" GUID="x1KlRA0eoUWd9ZF5ucGrTw==" type="FOTM.CS.c2"                                iconFile="Data/Fracs/skipGrd2.png"    iconSize="0.7"  profession="guardian"     rotate-x="-15" rotate-y="-15" rotate-z="222"/>
     <POI MapID="952" xpos="66.268" ypos="629.205" zpos="106.401" GUID="YmFq1+jrZEOTJzw1E4bRuQ==" type="FOTM.CS.c2"                                iconFile="Data/Fracs/WMPDexit.png"    iconSize="0.5"  profession="guardian"     rotate-x="180"/>
     <POI MapID="952" xpos="64.284" ypos="591.430" zpos="096.785" GUID="0rMXPgdqGk6zn89nFpCYKw==" type="FOTM.CS.c2"                                iconFile="Data/Fracs/Mes pExit.png"   iconSize="0.75" profession="mesmer"       rotate-x="180"                rotate-z="180"/>
     <POI MapID="952" xpos="58.289" ypos="612.994" zpos="103.089" GUID="x1KlRA0eoUWd9ZF5ucGrTw==" type="FOTM.CS.c2"                                iconFile="Data/Fracs/skipMes2.png"    iconSize="0.7"  profession="mesmer"       rotate-x="-15" rotate-y="-15" rotate-z="222"/>
@@ -240,7 +262,7 @@
     <POI MapID="959" xpos="44.2257"  ypos="162.309" zpos="-36.0883" GUID="xTTNQ1cRvkaQUMheUcBgFQ==" type="FOTM.MB.c2.sc3" fadeFar="1100" fadeNear="900"  iconFile="Data/Fracs/WMPDenter.png"  iconSize="0.5"  profession="necromancer"  rotate-x="180"/>
     <POI MapID="959" xpos="44.2257"  ypos="162.309" zpos="-36.0883" GUID="xTTNQ1cRvkaQUMheUcBgFQ==" type="FOTM.MB.c2.sc3" fadeFar="1100" fadeNear="900"  iconFile="Data/Fracs/WMPDenter.png"  iconSize="0.5"  profession="ranger"       rotate-x="180"/>
     <POI MapID="959" xpos="44.2257"  ypos="162.309" zpos="-36.0883" GUID="xTTNQ1cRvkaQUMheUcBgFQ==" type="FOTM.MB.c2.sc3" fadeFar="1100" fadeNear="900"  iconFile="Data/Fracs/WMPDenter.png"  iconSize="0.5"  profession="revenant"     rotate-x="180"/>
-    <POI MapID="959" xpos="44.2257"  ypos="162.309" zpos="-36.0883" GUID="xTTNQ1cRvkaQUMheUcBgFQ==" type="FOTM.MB.c2.sc3" fadeFar="1100" fadeNear="900"  iconFile="Data/Fracs/Thf pExit.png"  iconSize="0.5"  profession="thief"        rotate-x="180"/>
+    <POI MapID="959" xpos="44.2257"  ypos="162.309" zpos="-36.0883" GUID="xTTNQ1cRvkaQUMheUcBgFQ==" type="FOTM.MB.c2.sc3" fadeFar="1100" fadeNear="900"  iconFile="Data/Fracs/Thf pEnter.png"  iconSize="0.5"  profession="thief"        rotate-x="180"/>
     <POI MapID="959" xpos="44.2257"  ypos="162.309" zpos="-36.0883" GUID="xTTNQ1cRvkaQUMheUcBgFQ==" type="FOTM.MB.c2.sc3" fadeFar="1100" fadeNear="900"  iconFile="Data/Fracs/WMPDenter.png"  iconSize="0.5"  profession="warrior"      rotate-x="180"/>
     <POI MapID="959" xpos="25.7283"  ypos="156.061" zpos="-27.9474" GUID="hBQEdUMyQk+EIY4IECwCbw==" type="FOTM.MB.c2.sc3" fadeFar="1000" fadeNear="850"  iconFile="Data/Fracs/WMPDexit.png"   iconSize="0.65" profession="elementalist" rotate-x="180"                rotate-z="90"/>
     <POI MapID="959" xpos="25.7283"  ypos="156.061" zpos="-27.9474" GUID="hBQEdUMyQk+EIY4IECwCbw==" type="FOTM.MB.c2.sc3" fadeFar="1000" fadeNear="850"  iconFile="Data/Fracs/WMPDexit.png"   iconSize="0.65" profession="engineer"     rotate-x="180"                rotate-z="90"/>
@@ -249,7 +271,7 @@
     <POI MapID="959" xpos="25.7283"  ypos="156.061" zpos="-27.9474" GUID="hBQEdUMyQk+EIY4IECwCbw==" type="FOTM.MB.c2.sc3" fadeFar="1000" fadeNear="850"  iconFile="Data/Fracs/WMPDexit.png"   iconSize="0.65" profession="necromancer"  rotate-x="180"                rotate-z="90"/>
     <POI MapID="959" xpos="25.7283"  ypos="156.061" zpos="-27.9474" GUID="hBQEdUMyQk+EIY4IECwCbw==" type="FOTM.MB.c2.sc3" fadeFar="1000" fadeNear="850"  iconFile="Data/Fracs/WMPDexit.png"   iconSize="0.65" profession="ranger"       rotate-x="180"                rotate-z="90"/>
     <POI MapID="959" xpos="25.7283"  ypos="156.061" zpos="-27.9474" GUID="hBQEdUMyQk+EIY4IECwCbw==" type="FOTM.MB.c2.sc3" fadeFar="1000" fadeNear="850"  iconFile="Data/Fracs/WMPDexit.png"   iconSize="0.65" profession="revenant"     rotate-x="180"                rotate-z="90"/>
-    <POI MapID="959" xpos="25.7283"  ypos="156.061" zpos="-27.9474" GUID="hBQEdUMyQk+EIY4IECwCbw==" type="FOTM.MB.c2.sc3" fadeFar="1000" fadeNear="850"  iconFile="Data/Fracs/Thf pEnter.png" iconSize="0.65" profession="thief"        rotate-x="180"                rotate-z="90"/>
+    <POI MapID="959" xpos="25.7283"  ypos="156.061" zpos="-27.9474" GUID="hBQEdUMyQk+EIY4IECwCbw==" type="FOTM.MB.c2.sc3" fadeFar="1000" fadeNear="850"  iconFile="Data/Fracs/Thf pExit.png" iconSize="0.65" profession="thief"        rotate-x="180"                rotate-z="90"/>
     <POI MapID="959" xpos="25.7283"  ypos="156.061" zpos="-27.9474" GUID="hBQEdUMyQk+EIY4IECwCbw==" type="FOTM.MB.c2.sc3" fadeFar="1000" fadeNear="850"  iconFile="Data/Fracs/WMPDexit.png"   iconSize="0.65" profession="warrior"      rotate-x="180"                rotate-z="90"/>
     
     
@@ -470,6 +492,12 @@
     
     
     <!-- ======================================== UNCATEGORIZED ================================================================================================================================================================ -->
+    <!-- Skip to Old Tom -->
+    <POI MapID="947" xpos="-744.64"  ypos="824.410" zpos="-701.596" GUID="M2SmnshxYUasXsg6TO5Wkw==" type="FOTM.UC.c0" iconFile="Data/Fracs/skipEle1.png" profession="elementalist"/>
+    <POI MapID="947" xpos="-744.64"  ypos="824.410" zpos="-701.596" GUID="M2SmnshxYUasXsg6TO5Wkw==" type="FOTM.UC.c0" iconFile="Data/Fracs/skipGrd1.png" profession="guardian"/>
+    <POI MapID="947" xpos="-744.64"  ypos="824.410" zpos="-701.596" GUID="M2SmnshxYUasXsg6TO5Wkw==" type="FOTM.UC.c0" iconFile="Data/Fracs/skipMes1.png" profession="mesmer"/>
+    <POI MapID="947" xpos="-744.64"  ypos="824.410" zpos="-701.596" GUID="M2SmnshxYUasXsg6TO5Wkw==" type="FOTM.UC.c0" iconFile="Data/Fracs/skipNec1.png" profession="necromancer"/>
+    <POI MapID="947" xpos="-744.64"  ypos="824.410" zpos="-701.596" GUID="M2SmnshxYUasXsg6TO5Wkw==" type="FOTM.UC.c0" iconFile="Data/Fracs/skipThf1.png" profession="thief"/>
     <!-- JP Version -->
     <POI MapID="947" xpos="-773.973" ypos="838.598" zpos="-766.206" GUID="xmRtsVhexUCyM087px4mzg==" type="FOTM.UC.c1" iconFile="Data/Fracs/skip2.png"    iconSize="0.2"                            rotate-x="110" rotate-y="40"  rotate-z="250"/>
     <POI MapID="947" xpos="-773.709" ypos="839.839" zpos="-765.221" GUID="3eMN6GYkTUyO9/RE+5q+Tw==" type="FOTM.UC.c1" iconFile="Data/Fracs/skip1.png"    iconSize="0.2"                            rotate-x="85"  rotate-y="20"  rotate-z="225"/>
@@ -530,9 +558,9 @@
     <POI MapID="947" xpos="-824.750" ypos="841.934" zpos="-729.816" GUID="Q3pB7fmuVkm7erxOABdX+Q==" type="FOTM.UC.c2" iconFile="Data/Fracs/skipRea2.png" iconSize="0.35" specialization="34"       rotate-x="30"  rotate-y="-25" rotate-z="95"/>
     <POI MapID="947" xpos="-839.388" ypos="843.500" zpos="-719.574" GUID="WLVDKrDMdkiYzqt8A9sfRA==" type="FOTM.UC.c2" iconFile="Data/Fracs/skipRea2.png" iconSize="0.25" specialization="34"       rotate-x="30"  rotate-y="-25" rotate-z="60"/>
     <POI MapID="947" xpos="-842.013" ypos="857.209" zpos="-706.293" GUID="y/A1JLvboU6goza818v4rg==" type="FOTM.UC.c2" iconFile="Data/Fracs/skipRea1.png" iconSize="0.5"  specialization="34"       rotate-x="125" rotate-y="17"  rotate-z="150"/>
-    <POI MapID="947" xpos="-824.750" ypos="841.934" zpos="-729.816" GUID="Q3pB7fmuVkm7erxOABdX+Q==" type="FOTM.UC.c2" iconFile="Data/Fracs/skipSlb2.png" iconSize="0.35" specialization="55"       rotate-x="30"  rotate-y="-25" rotate-z="95"/>
-    <POI MapID="947" xpos="-839.388" ypos="843.500" zpos="-719.574" GUID="WLVDKrDMdkiYzqt8A9sfRA==" type="FOTM.UC.c2" iconFile="Data/Fracs/skipSlb2.png" iconSize="0.25" specialization="55"       rotate-x="30"  rotate-y="-25" rotate-z="60"/>
-    <POI MapID="947" xpos="-842.013" ypos="857.209" zpos="-706.293" GUID="y/A1JLvboU6goza818v4rg==" type="FOTM.UC.c2" iconFile="Data/Fracs/skipSlb1.png" iconSize="0.5"  specialization="55"       rotate-x="125" rotate-y="17"  rotate-z="150"/>
+    <POI MapID="947" xpos="-824.750" ypos="841.934" zpos="-729.816" GUID="Q3pB7fmuVkm7erxOABdX+Q==" type="FOTM.UC.c2" iconFile="Data/Fracs/skipSlb2.png" iconSize="0.35" profession="ranger"       rotate-x="30"  rotate-y="-25" rotate-z="95"/>
+    <POI MapID="947" xpos="-839.388" ypos="843.500" zpos="-719.574" GUID="WLVDKrDMdkiYzqt8A9sfRA==" type="FOTM.UC.c2" iconFile="Data/Fracs/skipSlb2.png" iconSize="0.25" profession="ranger"       rotate-x="30"  rotate-y="-25" rotate-z="60"/>
+    <POI MapID="947" xpos="-842.013" ypos="857.209" zpos="-706.293" GUID="y/A1JLvboU6goza818v4rg==" type="FOTM.UC.c2" iconFile="Data/Fracs/skipSlb1.png" iconSize="0.5"  profession="ranger"       rotate-x="125" rotate-y="17"  rotate-z="150"/>
     <POI MapID="947" xpos="-824.750" ypos="841.934" zpos="-729.816" GUID="Q3pB7fmuVkm7erxOABdX+Q==" type="FOTM.UC.c2" iconFile="Data/Fracs/skipEng2.png" iconSize="0.35" profession="engineer"     rotate-x="30"  rotate-y="-25" rotate-z="95"/>
     <POI MapID="947" xpos="-839.388" ypos="843.500" zpos="-719.574" GUID="WLVDKrDMdkiYzqt8A9sfRA==" type="FOTM.UC.c2" iconFile="Data/Fracs/skipEng2.png" iconSize="0.25" profession="engineer"     rotate-x="30"  rotate-y="-25" rotate-z="60"/>
     <POI MapID="947" xpos="-842.013" ypos="857.209" zpos="-706.293" GUID="y/A1JLvboU6goza818v4rg==" type="FOTM.UC.c2" iconFile="Data/Fracs/skipEng1.png" iconSize="0.5"  profession="engineer"     rotate-x="125" rotate-y="17"  rotate-z="150"/>
@@ -575,53 +603,15 @@
     
     <!-- ======================================== URBAN BATTLEGROUND =========================================================================================================================================================== -->
     <!-- Burning Oil Boundary -->
-    <Trail trailData="Data/Fracs/UB Oils.trl" animSpeed="2" alpha="1"                            type="FOTM.UB.c1"     fadeFar="1500" fadeNear="1000" texture="Data/Fracs/redtrail.png"/>
-    <!-- Both Skips -->
-	<POI MapID="950" xpos="286.715" ypos="07.000" zpos="686.865" GUID="OrbSrzXOGUaNGaOsglaHpg==" type="FOTM.UB.c2"     fadeFar="1750" fadeNear="1500" iconFile="Data/Fracs/skip1.png"     iconSize="0.45"                       rotate-x="270" rotate-y="180" rotate-z="225"/>
-	<POI MapID="950" xpos="275.598" ypos="10.871" zpos="675.902" GUID="VLKxx9gDQUi2ERBZ3gRWPA==" type="FOTM.UB.c2"     fadeFar="900"  fadeNear="700"  iconFile="Data/Fracs/skip2.png"     iconSize="0.25"                       rotate-x="80"  rotate-y="45"  rotate-z="-60"/>
-	<POI MapID="950" xpos="278.345" ypos="12.860" zpos="681.080" GUID="aQ1ysElmCU6TV50ceMvFHw==" type="FOTM.UB.c2"     fadeFar="700"  fadeNear="500"  iconFile="Data/Fracs/skip2.png"     iconSize="0.25"                       rotate-x="80"  rotate-y="44"  rotate-z="140"/>
-    <POI MapID="950" xpos="281.602" ypos="17.163" zpos="688.230" GUID="L8DR9sxmQUazZ2OyCFw21A==" type="FOTM.UB.c2"     fadeFar="550"  fadeNear="400"  iconFile="Data/Fracs/skip1.png"     iconSize="0.5"                        rotate-x="90"                 rotate-z="150"/>
-	<POI MapID="950" xpos="267.448" ypos="18.302" zpos="692.747" GUID="4O1JFOyP9kOPZfytnlCW/Q==" type="FOTM.UB.c2"     fadeFar="850"  fadeNear="600"  iconFile="Data/Fracs/skip1.png"     iconSize="0.65"                       rotate-x="140"                rotate-z="-60"/>
-    <!-- Variant 1 -->
-	<POI MapID="950" xpos="257.040" ypos="23.330" zpos="698.135" GUID="Lo8bMzFf7kyYlJZnlplKwg==" type="FOTM.UB.c2.sc1" fadeFar="1000" fadeNear="750"  iconFile="Data/Fracs/skip1.png"     iconSize="0.5"                        rotate-x="38"  rotate-y="-5"  rotate-z="-55"/>
-	<POI MapID="950" xpos="217.298" ypos="11.038" zpos="714.105" GUID="EVBQFGDvNkS+yA+OiGXt0Q==" type="FOTM.UB.c2.sc1" fadeFar="1850" fadeNear="1600" iconFile="Data/Fracs/skip1y.png"    iconSize="1"                          rotate-x="90"                 rotate-z="225"/>
-    <!-- Variant 2 -->
-    <POI MapID="950" xpos="237.442" ypos="23.888" zpos="681.340" GUID="vKd0JOhlekunhUzAgX5P5g==" type="FOTM.UB.c2.sc2" fadeFar="1500" fadeNear="1250" iconFile="Data/Fracs/skipMir1.png"  iconSize="0.75" specialization="59"   rotate-x="50"  rotate-y="-5"  rotate-z="125"/>
-	<POI MapID="950" xpos="228.480" ypos="28.920" zpos="674.606" GUID="rUIXK+erEEmihvVPMRPPLg==" type="FOTM.UB.c2.sc2" fadeFar="1000" fadeNear="750"  iconFile="Data/Fracs/skipMir2.png"  iconSize="0.25" specialization="59"   rotate-x="90"  rotate-y="15"  rotate-z="-70"/>
-	<POI MapID="950" xpos="228.487" ypos="36.245" zpos="671.329" GUID="n0Ej/pc4nEiJD+VbtO/Ziw==" type="FOTM.UB.c2.sc2" fadeFar="1000" fadeNear="750"  iconFile="Data/Fracs/skipMir1.png"  iconSize="0.35" specialization="59"   rotate-x="90"  rotate-y="-5"  rotate-z="110"/>
-	<POI MapID="950" xpos="218.925" ypos="43.084" zpos="697.627" GUID="EXR3ER5x9k6W+grCzi4xsA==" type="FOTM.UB.c2.sc2" fadeFar="1250" fadeNear="1150" iconFile="Data/Fracs/skipMir2.png"  iconSize="1"    specialization="59"   rotate-x="40"  rotate-y="38"  rotate-z="-75"/>
-	<POI MapID="950" xpos="212.832" ypos="38.177" zpos="721.905" GUID="j6Y1Mo5OkkmJYjwVDSxjgA==" type="FOTM.UB.c2.sc2" fadeFar="1600" fadeNear="1350" iconFile="Data/Fracs/skipMir1.png"  iconSize="0.75" specialization="59"   rotate-x="30"  rotate-y="-5"  rotate-z="10"/>
-	<POI MapID="950" xpos="205.592" ypos="29.042" zpos="737.396" GUID="VY6A4zJsRUuEDsnnTRByEQ==" type="FOTM.UB.c2.sc2" fadeFar="1000" fadeNear="750"  iconFile="Data/Fracs/skipMir1.png"  iconSize="1"    specialization="59"   rotate-x="0.1"                rotate-z="35"/>
-    <POI MapID="950" xpos="237.442" ypos="23.888" zpos="681.340" GUID="vKd0JOhlekunhUzAgX5P5g==" type="FOTM.UB.c2.sc2" fadeFar="1500" fadeNear="1250" iconFile="Data/Fracs/skipRea1.png"  iconSize="0.75" specialization="34"   rotate-x="50"  rotate-y="-5"  rotate-z="125"/>
-	<POI MapID="950" xpos="228.480" ypos="28.920" zpos="674.606" GUID="rUIXK+erEEmihvVPMRPPLg==" type="FOTM.UB.c2.sc2" fadeFar="1000" fadeNear="750"  iconFile="Data/Fracs/skipRea2.png"  iconSize="0.25" specialization="34"   rotate-x="90"  rotate-y="15"  rotate-z="-70"/>
-	<POI MapID="950" xpos="228.487" ypos="36.245" zpos="671.329" GUID="n0Ej/pc4nEiJD+VbtO/Ziw==" type="FOTM.UB.c2.sc2" fadeFar="1000" fadeNear="750"  iconFile="Data/Fracs/skipRea1.png"  iconSize="0.35" specialization="34"   rotate-x="90"  rotate-y="-5"  rotate-z="110"/>
-	<POI MapID="950" xpos="218.925" ypos="43.084" zpos="697.627" GUID="EXR3ER5x9k6W+grCzi4xsA==" type="FOTM.UB.c2.sc2" fadeFar="1250" fadeNear="1150" iconFile="Data/Fracs/skipRea2.png"  iconSize="1"    specialization="34"   rotate-x="40"  rotate-y="38"  rotate-z="-75"/>
-	<POI MapID="950" xpos="212.832" ypos="38.177" zpos="721.905" GUID="j6Y1Mo5OkkmJYjwVDSxjgA==" type="FOTM.UB.c2.sc2" fadeFar="1600" fadeNear="1350" iconFile="Data/Fracs/skipRea1.png"  iconSize="0.75" specialization="34"   rotate-x="30"  rotate-y="-5"  rotate-z="10"/>
-	<POI MapID="950" xpos="205.592" ypos="29.042" zpos="737.396" GUID="VY6A4zJsRUuEDsnnTRByEQ==" type="FOTM.UB.c2.sc2" fadeFar="1000" fadeNear="750"  iconFile="Data/Fracs/skipRea1.png"  iconSize="1"    specialization="34"   rotate-x="0.1"                rotate-z="35"/>
-    <POI MapID="950" xpos="237.442" ypos="23.888" zpos="681.340" GUID="vKd0JOhlekunhUzAgX5P5g==" type="FOTM.UB.c2.sc2" fadeFar="1500" fadeNear="1250" iconFile="Data/Fracs/skipEng1.png"  iconSize="0.75" profession="engineer" rotate-x="50"  rotate-y="-5"  rotate-z="125"/>
-	<POI MapID="950" xpos="228.480" ypos="28.920" zpos="674.606" GUID="rUIXK+erEEmihvVPMRPPLg==" type="FOTM.UB.c2.sc2" fadeFar="1000" fadeNear="750"  iconFile="Data/Fracs/skipEng2.png"  iconSize="0.25" profession="engineer" rotate-x="90"  rotate-y="15"  rotate-z="-70"/>
-	<POI MapID="950" xpos="228.487" ypos="36.245" zpos="671.329" GUID="n0Ej/pc4nEiJD+VbtO/Ziw==" type="FOTM.UB.c2.sc2" fadeFar="1000" fadeNear="750"  iconFile="Data/Fracs/skipEng1.png"  iconSize="0.35" profession="engineer" rotate-x="90"  rotate-y="-5"  rotate-z="110"/>
-	<POI MapID="950" xpos="218.925" ypos="43.084" zpos="697.627" GUID="EXR3ER5x9k6W+grCzi4xsA==" type="FOTM.UB.c2.sc2" fadeFar="1250" fadeNear="1150" iconFile="Data/Fracs/skipEng2.png"  iconSize="1"    profession="engineer" rotate-x="40"  rotate-y="38"  rotate-z="-75"/>
-	<POI MapID="950" xpos="212.832" ypos="38.177" zpos="721.905" GUID="j6Y1Mo5OkkmJYjwVDSxjgA==" type="FOTM.UB.c2.sc2" fadeFar="1600" fadeNear="1350" iconFile="Data/Fracs/skipEng1.png"  iconSize="0.75" profession="engineer" rotate-x="30"  rotate-y="-5"  rotate-z="10"/>
-	<POI MapID="950" xpos="205.592" ypos="29.042" zpos="737.396" GUID="VY6A4zJsRUuEDsnnTRByEQ==" type="FOTM.UB.c2.sc2" fadeFar="1000" fadeNear="750"  iconFile="Data/Fracs/skipEng1.png"  iconSize="1"    profession="engineer" rotate-x="0.1"                rotate-z="35"/>
-    <POI MapID="950" xpos="237.442" ypos="23.888" zpos="681.340" GUID="vKd0JOhlekunhUzAgX5P5g==" type="FOTM.UB.c2.sc2" fadeFar="1500" fadeNear="1250" iconFile="Data/Fracs/skipGrd1.png"  iconSize="0.75" profession="guardian" rotate-x="50"  rotate-y="-5"  rotate-z="125"/>
-	<POI MapID="950" xpos="228.480" ypos="28.920" zpos="674.606" GUID="rUIXK+erEEmihvVPMRPPLg==" type="FOTM.UB.c2.sc2" fadeFar="1000" fadeNear="750"  iconFile="Data/Fracs/skipGrd2.png"  iconSize="0.25" profession="guardian" rotate-x="90"  rotate-y="15"  rotate-z="-70"/>
-	<POI MapID="950" xpos="228.487" ypos="36.245" zpos="671.329" GUID="n0Ej/pc4nEiJD+VbtO/Ziw==" type="FOTM.UB.c2.sc2" fadeFar="1000" fadeNear="750"  iconFile="Data/Fracs/skipGrd1.png"  iconSize="0.35" profession="guardian" rotate-x="90"  rotate-y="-5"  rotate-z="110"/>
-	<POI MapID="950" xpos="218.925" ypos="43.084" zpos="697.627" GUID="EXR3ER5x9k6W+grCzi4xsA==" type="FOTM.UB.c2.sc2" fadeFar="1250" fadeNear="1150" iconFile="Data/Fracs/skipGrd2.png"  iconSize="1"    profession="guardian" rotate-x="40"  rotate-y="38"  rotate-z="-75"/>
-	<POI MapID="950" xpos="212.832" ypos="38.177" zpos="721.905" GUID="j6Y1Mo5OkkmJYjwVDSxjgA==" type="FOTM.UB.c2.sc2" fadeFar="1600" fadeNear="1350" iconFile="Data/Fracs/skipGrd1.png"  iconSize="0.75" profession="guardian" rotate-x="30"  rotate-y="-5"  rotate-z="10"/>
-	<POI MapID="950" xpos="205.592" ypos="29.042" zpos="737.396" GUID="VY6A4zJsRUuEDsnnTRByEQ==" type="FOTM.UB.c2.sc2" fadeFar="1000" fadeNear="750"  iconFile="Data/Fracs/skipGrd1.png"  iconSize="1"    profession="guardian" rotate-x="0.1"                rotate-z="35"/>
-    <POI MapID="950" xpos="237.442" ypos="23.888" zpos="681.340" GUID="vKd0JOhlekunhUzAgX5P5g==" type="FOTM.UB.c2.sc2" fadeFar="1500" fadeNear="1250" iconFile="Data/Fracs/skipRgr1.png"  iconSize="0.75" profession="ranger"   rotate-x="50"  rotate-y="-5"  rotate-z="125"/>
-	<POI MapID="950" xpos="228.480" ypos="28.920" zpos="674.606" GUID="rUIXK+erEEmihvVPMRPPLg==" type="FOTM.UB.c2.sc2" fadeFar="1000" fadeNear="750"  iconFile="Data/Fracs/skipRgr2.png"  iconSize="0.25" profession="ranger"   rotate-x="90"  rotate-y="15"  rotate-z="-70"/>
-	<POI MapID="950" xpos="228.487" ypos="36.245" zpos="671.329" GUID="n0Ej/pc4nEiJD+VbtO/Ziw==" type="FOTM.UB.c2.sc2" fadeFar="1000" fadeNear="750"  iconFile="Data/Fracs/skipRgr1.png"  iconSize="0.35" profession="ranger"   rotate-x="90"  rotate-y="-5"  rotate-z="110"/>
-	<POI MapID="950" xpos="218.925" ypos="43.084" zpos="697.627" GUID="EXR3ER5x9k6W+grCzi4xsA==" type="FOTM.UB.c2.sc2" fadeFar="1250" fadeNear="1150" iconFile="Data/Fracs/skipRgr2.png"  iconSize="1"    profession="ranger"   rotate-x="40"  rotate-y="38"  rotate-z="-75"/>
-	<POI MapID="950" xpos="212.832" ypos="38.177" zpos="721.905" GUID="j6Y1Mo5OkkmJYjwVDSxjgA==" type="FOTM.UB.c2.sc2" fadeFar="1600" fadeNear="1350" iconFile="Data/Fracs/skipRgr1.png"  iconSize="0.75" profession="ranger"   rotate-x="30"  rotate-y="-5"  rotate-z="10"/>
-	<POI MapID="950" xpos="205.592" ypos="29.042" zpos="737.396" GUID="VY6A4zJsRUuEDsnnTRByEQ==" type="FOTM.UB.c2.sc2" fadeFar="1000" fadeNear="750"  iconFile="Data/Fracs/skipRgr1.png"  iconSize="1"    profession="ranger"   rotate-x="0.1"                rotate-z="35"/>
-    <POI MapID="950" xpos="237.442" ypos="23.888" zpos="681.340" GUID="vKd0JOhlekunhUzAgX5P5g==" type="FOTM.UB.c2.sc2" fadeFar="1500" fadeNear="1250" iconFile="Data/Fracs/skipWar1.png"  iconSize="0.75" profession="warrior"  rotate-x="50"  rotate-y="-5"  rotate-z="125"/>
-	<POI MapID="950" xpos="228.480" ypos="28.920" zpos="674.606" GUID="rUIXK+erEEmihvVPMRPPLg==" type="FOTM.UB.c2.sc2" fadeFar="1000" fadeNear="750"  iconFile="Data/Fracs/skipWar2.png"  iconSize="0.25" profession="warrior"  rotate-x="90"  rotate-y="15"  rotate-z="-70"/>
-	<POI MapID="950" xpos="228.487" ypos="36.245" zpos="671.329" GUID="n0Ej/pc4nEiJD+VbtO/Ziw==" type="FOTM.UB.c2.sc2" fadeFar="1000" fadeNear="750"  iconFile="Data/Fracs/skipWar1.png"  iconSize="0.35" profession="warrior"  rotate-x="90"  rotate-y="-5"  rotate-z="110"/>
-	<POI MapID="950" xpos="218.925" ypos="43.084" zpos="697.627" GUID="EXR3ER5x9k6W+grCzi4xsA==" type="FOTM.UB.c2.sc2" fadeFar="1250" fadeNear="1150" iconFile="Data/Fracs/skipWar2.png"  iconSize="1"    profession="warrior"  rotate-x="40"  rotate-y="38"  rotate-z="-75"/>
-	<POI MapID="950" xpos="212.832" ypos="38.177" zpos="721.905" GUID="j6Y1Mo5OkkmJYjwVDSxjgA==" type="FOTM.UB.c2.sc2" fadeFar="1600" fadeNear="1350" iconFile="Data/Fracs/skipWar1.png"  iconSize="0.75" profession="warrior"  rotate-x="30"  rotate-y="-5"  rotate-z="10"/>
-	<POI MapID="950" xpos="205.592" ypos="29.042" zpos="737.396" GUID="VY6A4zJsRUuEDsnnTRByEQ==" type="FOTM.UB.c2.sc2" fadeFar="1000" fadeNear="750"  iconFile="Data/Fracs/skipWar1.png"  iconSize="1"    profession="warrior"  rotate-x="0.1"                rotate-z="35"/>
+    <Trail trailData="Data/Fracs/UB Oils.trl" animSpeed="2" alpha="1"                            type="FOTM.UB.c1" fadeFar="1500" fadeNear="1000" texture="Data/Fracs/redtrail.png"/>
+    <!-- Barricade Skip -->
+	<POI MapID="950" xpos="286.715" ypos="07.000" zpos="686.865" GUID="OrbSrzXOGUaNGaOsglaHpg==" type="FOTM.UB.c2" fadeFar="1750" fadeNear="1500" iconFile="Data/Fracs/skip1.png"     iconSize="0.45" rotate-x="270" rotate-y="180" rotate-z="225"/>
+	<POI MapID="950" xpos="275.598" ypos="10.871" zpos="675.902" GUID="VLKxx9gDQUi2ERBZ3gRWPA==" type="FOTM.UB.c2" fadeFar="900"  fadeNear="700"  iconFile="Data/Fracs/skip2.png"     iconSize="0.25" rotate-x="80"  rotate-y="45"  rotate-z="-60"/>
+	<POI MapID="950" xpos="278.345" ypos="12.860" zpos="681.080" GUID="aQ1ysElmCU6TV50ceMvFHw==" type="FOTM.UB.c2" fadeFar="700"  fadeNear="500"  iconFile="Data/Fracs/skip2.png"     iconSize="0.25" rotate-x="80"  rotate-y="44"  rotate-z="140"/>
+    <POI MapID="950" xpos="281.602" ypos="17.163" zpos="688.230" GUID="L8DR9sxmQUazZ2OyCFw21A==" type="FOTM.UB.c2" fadeFar="550"  fadeNear="400"  iconFile="Data/Fracs/skip1.png"     iconSize="0.5"  rotate-x="90"                 rotate-z="150"/>
+	<POI MapID="950" xpos="267.448" ypos="18.302" zpos="692.747" GUID="4O1JFOyP9kOPZfytnlCW/Q==" type="FOTM.UB.c2" fadeFar="850"  fadeNear="600"  iconFile="Data/Fracs/skip1.png"     iconSize="0.65" rotate-x="140"                rotate-z="-60"/>
+	<POI MapID="950" xpos="257.040" ypos="23.330" zpos="698.135" GUID="Lo8bMzFf7kyYlJZnlplKwg==" type="FOTM.UB.c2" fadeFar="1000" fadeNear="750"  iconFile="Data/Fracs/skip1.png"     iconSize="0.5"  rotate-x="38"  rotate-y="-5"  rotate-z="-55"/>
+	<POI MapID="950" xpos="217.298" ypos="11.038" zpos="714.105" GUID="EVBQFGDvNkS+yA+OiGXt0Q==" type="FOTM.UB.c2" fadeFar="1850" fadeNear="1600" iconFile="Data/Fracs/skip1y.png"    iconSize="1"    rotate-x="90"                 rotate-z="225"/>
     
     
     <!-- ======================================== VOLCANIC ===================================================================================================================================================================== -->
@@ -632,8 +622,8 @@
     <POI MapID="954" xpos="232.187" ypos="52.805" zpos="-691.025" GUID="JOYULwXHK0Gu5GV8aY9CyQ==" type="FOTM.Vo.c1" fadeFar="900"  fadeNear="750"  iconFile="Data/Fracs/WMPDexit.png"  profession="engineer"     rotate-x="173" rotate-y="-5"  rotate-z="114"/>
     <POI MapID="954" xpos="350.135" ypos="81.000" zpos="-716.496" GUID="4bFCZMjeJESnDAfAWNvqSA==" type="FOTM.Vo.c1" fadeFar="600"  fadeNear="400"  iconFile="Data/Fracs/WMPDenter.png" profession="guardian"     rotate-x="170" rotate-y="-10" rotate-z="225"/>
     <POI MapID="954" xpos="232.187" ypos="52.805" zpos="-691.025" GUID="JOYULwXHK0Gu5GV8aY9CyQ==" type="FOTM.Vo.c1" fadeFar="900"  fadeNear="750"  iconFile="Data/Fracs/WMPDexit.png"  profession="guardian"     rotate-x="173" rotate-y="-5"  rotate-z="114"/>
-    <POI MapID="954" xpos="350.135" ypos="81.000" zpos="-716.496" GUID="4bFCZMjeJESnDAfAWNvqSA==" type="FOTM.Vo.c1" fadeFar="600"  fadeNear="400"  iconFile="Data/Fracs/pEnter.png"    profession="mesmer"       rotate-x="170" rotate-y="-10" rotate-z="225"/>
-    <POI MapID="954" xpos="232.187" ypos="52.805" zpos="-691.025" GUID="JOYULwXHK0Gu5GV8aY9CyQ==" type="FOTM.Vo.c1" fadeFar="900"  fadeNear="750"  iconFile="Data/Fracs/pExit.png"     profession="mesmer"       rotate-x="173" rotate-y="-5"  rotate-z="114"/>
+    <POI MapID="954" xpos="350.135" ypos="81.000" zpos="-716.496" GUID="4bFCZMjeJESnDAfAWNvqSA==" type="FOTM.Vo.c1" fadeFar="600"  fadeNear="400"  iconFile="Data/Fracs/Mes pEnter.png"    profession="mesmer"       rotate-x="170" rotate-y="-10" rotate-z="225"/>
+    <POI MapID="954" xpos="232.187" ypos="52.805" zpos="-691.025" GUID="JOYULwXHK0Gu5GV8aY9CyQ==" type="FOTM.Vo.c1" fadeFar="900"  fadeNear="750"  iconFile="Data/Fracs/Mes pExit.png"     profession="mesmer"       rotate-x="173" rotate-y="-5"  rotate-z="114"/>
     <POI MapID="954" xpos="350.135" ypos="81.000" zpos="-716.496" GUID="4bFCZMjeJESnDAfAWNvqSA==" type="FOTM.Vo.c1" fadeFar="600"  fadeNear="400"  iconFile="Data/Fracs/WMPDenter.png" profession="necromancer"  rotate-x="170" rotate-y="-10" rotate-z="225"/>
     <POI MapID="954" xpos="232.187" ypos="52.805" zpos="-691.025" GUID="JOYULwXHK0Gu5GV8aY9CyQ==" type="FOTM.Vo.c1" fadeFar="900"  fadeNear="750"  iconFile="Data/Fracs/WMPDexit.png"  profession="necromancer"  rotate-x="173" rotate-y="-5"  rotate-z="114"/>
     <POI MapID="954" xpos="350.135" ypos="81.000" zpos="-716.496" GUID="4bFCZMjeJESnDAfAWNvqSA==" type="FOTM.Vo.c1" fadeFar="600"  fadeNear="400"  iconFile="Data/Fracs/WMPDenter.png" profession="ranger"       rotate-x="170" rotate-y="-10" rotate-z="225"/>

--- a/Blish HUD/Raids.xml
+++ b/Blish HUD/Raids.xml
@@ -2,7 +2,7 @@
 <!-- ================================================== BLISH HUD VERSION ================================================== -->
 <!-- ======================================================================================================================= -->
 <OverlayData>
-  <MarkerCategory name="Raid" DisplayName="Raid">
+  <MarkerCategory      name="Raid" DisplayName="Raids">
     <MarkerCategory    name="Ti"   DisplayName="Hero's Marker Pack" IsSeparator="1"/>
     <!-- ========== SPIRIT VALE ================================================================================================================================================================================================ -->
     <MarkerCategory     name="W1" DisplayName="Spirit Vale">
@@ -32,21 +32,21 @@
             <MarkerCategory name="m4"  DisplayName="Mushroom 4"                  defaultToggle="0"/>
           </MarkerCategory>
           <MarkerCategory   name="sc3" DisplayName="Outer"          behavior="4" defaultToggle="0"                                                                     iconSize="0.4" resetLength="59" triggerRange="5">
-            <MarkerCategory name="m1"  DisplayName="Mushroom 1"/>
-            <MarkerCategory name="m2"  DisplayName="Mushroom 2"/>
-            <MarkerCategory name="m3"  DisplayName="Mushroom 3"/>
-            <MarkerCategory name="m4"  DisplayName="Mushroom 4"/>
+            <MarkerCategory name="m1"  DisplayName="Mushroom 1"                  defaultToggle="1"/>
+            <MarkerCategory name="m2"  DisplayName="Mushroom 2"                  defaultToggle="0"/>
+            <MarkerCategory name="m3"  DisplayName="Mushroom 3"                  defaultToggle="0"/>
+            <MarkerCategory name="m4"  DisplayName="Mushroom 4"                  defaultToggle="0"/>
           </MarkerCategory>
           <MarkerCategory   name="sc4" DisplayName="Center"         behavior="4" defaultToggle="0"                                                                     iconSize="0.4" resetLength="59" triggerRange="5">
-            <MarkerCategory name="m1"  DisplayName="Mushroom 1"/>
-            <MarkerCategory name="m2"  DisplayName="Mushroom 2"/>
-            <MarkerCategory name="m3"  DisplayName="Mushroom 3"/>
-            <MarkerCategory name="m4"  DisplayName="Mushroom 4"/>
+            <MarkerCategory name="m1"  DisplayName="Mushroom 1"                  defaultToggle="1"/>
+            <MarkerCategory name="m2"  DisplayName="Mushroom 2"                  defaultToggle="0"/>
+            <MarkerCategory name="m3"  DisplayName="Mushroom 3"                  defaultToggle="0"/>
+            <MarkerCategory name="m4"  DisplayName="Mushroom 4"                  defaultToggle="0"/>
           </MarkerCategory>
           <MarkerCategory   name="sc5" DisplayName="Minimal Eating" behavior="4" defaultToggle="0"                                                                     iconSize="0.4" resetLength="59" triggerRange="5">
-            <MarkerCategory name="m1"  DisplayName="Mushroom 1"/>
-            <MarkerCategory name="m2"  DisplayName="Mushroom 2"/>
-            <MarkerCategory name="m3"  DisplayName="Mushroom 3"/>
+            <MarkerCategory name="m1"  DisplayName="Mushroom 1"                  defaultToggle="1"/>
+            <MarkerCategory name="m2"  DisplayName="Mushroom 2"                  defaultToggle="0"/>
+            <MarkerCategory name="m3"  DisplayName="Mushroom 3"                  defaultToggle="0"/>
           </MarkerCategory>          
         </MarkerCategory>
         <MarkerCategory     name="c2"  DisplayName="Timer"          fadeFar="1250" fadeNear="1000"                                iconFile="Data/Raids/starttimer.png" iconSize="1"/>
@@ -76,7 +76,10 @@
     <!-- ========== BASTION OF THE PENITENT ==================================================================================================================================================================================== -->
     <MarkerCategory     name="W4" DisplayName="Bastion of the Penitent">
       <MarkerCategory   name="B1" DisplayName="Cairn"                   fadeFar="4000" fadeNear="3500">
-        <MarkerCategory name="c1" DisplayName="Agony"                                                                                         iconSize="0.5"  rotate-x="180"/>
+        <MarkerCategory name="c1" DisplayName="Agony Spots" iconSize="0.5"  rotate-x="180" iconFile="Data/Multi/dot.png"                rotate-z="15">
+          <MarkerCategory name="sc1" DisplayName="Kite"/>
+          <MarkerCategory name="sc2" DisplayName="No-Kite" defaultToggle="0"/>
+        </MarkerCategory>
         <MarkerCategory name="c2" DisplayName="Timer"                                                  iconFile="Data/Raids/starttimer.png"   iconSize="1"/>
       </MarkerCategory>
       <MarkerCategory   name="B2" DisplayName="Mursaat Overseer"        fadeFar="1500" fadeNear="1250" iconFile="Data/Raids/starttimer.png"   iconSize="1"/>
@@ -109,7 +112,7 @@
         <MarkerCategory   name="c1" DisplayName="Boundary"                                                                                                fadeFar="150"  fadeNear="125"/>
         <MarkerCategory   name="c2" DisplayName="Shield/Sword"                                                                                            fadeFar="3000" fadeNear="2500"                                iconSize="0.75" rotate-x="180"/>
       </MarkerCategory>
-      <MarkerCategory     name="B2" DisplayName="Twin Largos"         bounce-duration="120" bounce-distance="43" bounce-height="-31" bounce-when="inzone" fadeFar="2000" fadeNear="1750"                                                rotate-x="90"  title-color="yellow"/>
+      <MarkerCategory     name="B2" DisplayName="Twin Largos"         bounce-duration="115" bounce-distance="43" bounce-height="-31" bounce-when="inzone" fadeFar="2000" fadeNear="1750"                                                rotate-x="90"  title-color="yellow"/>
       <MarkerCategory     name="B3" DisplayName="Qadim">
         <MarkerCategory   name="c1" DisplayName="Boon Pyres"                                                                                              fadeFar="5000" fadeNear="4500"                                iconSize="0.75"/>
         <MarkerCategory   name="c2" DisplayName="Lamp"                                                                                                    fadeFar="3000" fadeNear="2000"                                                rotate-x="180">
@@ -348,12 +351,14 @@
     
     <!-- ======================================== BASTION OF THE PENITENT ====================================================================================================================================================== -->
     <!-- ==================== Cairn ==================== -->
-    <!-- Agony Spots -->
-    <POI MapID="1188" xpos="0369.295" ypos="032.120" zpos="0052.475" GUID="wedtPfCXTEugS91HgQoMkg==" type="Raid.W4.B1.c1" iconFile="Data/Multi/dot.png"                rotate-z="15"/>
-    <POI MapID="1188" xpos="0359.920" ypos="032.120" zpos="0050.043" GUID="sKrUfpjhCkqx1MObpkeN/w==" type="Raid.W4.B1.c1" iconFile="Data/Multi/dot.png"                rotate-z="15"/>
-    <POI MapID="1188" xpos="0361.518" ypos="032.120" zpos="0063.235" GUID="MPL7+6k9ok2ajPAdN+b7yA==" type="Raid.W4.B1.c1" iconFile="Data/Multi/dot.png"                rotate-z="15"/>
-    <!-- Kiter -->
-    <POI MapID="1188" xpos="0369.301" ypos="032.120" zpos="0034.189" GUID="xXkIzhbDjkC7KmaMBOeoag==" type="Raid.W4.B1.c1" iconFile="Data/Multi/dot.png"                rotate-z="15"/>
+    <POI MapID="1188" xpos="369.295" ypos="32.120" zpos="52.475" GUID="wedtPfCXTEugS91HgQoMkg==" type="Raid.W4.B1.c1.sc1"/>
+    <POI MapID="1188" xpos="359.920" ypos="32.120" zpos="50.043" GUID="sKrUfpjhCkqx1MObpkeN/w==" type="Raid.W4.B1.c1.sc1"/>
+    <POI MapID="1188" xpos="361.518" ypos="32.120" zpos="63.235" GUID="MPL7+6k9ok2ajPAdN+b7yA==" type="Raid.W4.B1.c1.sc1"/>
+    <POI MapID="1188" xpos="369.301" ypos="32.120" zpos="34.189" GUID="xXkIzhbDjkC7KmaMBOeoag==" type="Raid.W4.B1.c1.sc1"/>
+    <POI MapID="1188" xpos="359.106" ypos="32.120" zpos="50.503" GUID="AYCnJxIgn0+DxviFHb7TBg==" type="Raid.W4.B1.c1.sc2"/>
+	<POI MapID="1188" xpos="368.492" ypos="32.120" zpos="47.646" GUID="edOmOFblmECujARKFnbbig==" type="Raid.W4.B1.c1.sc2"/>
+	<POI MapID="1188" xpos="362.802" ypos="32.120" zpos="46.023" GUID="wka32siebUi9HZLbkKCgcA==" type="Raid.W4.B1.c1.sc2"/>
+	<POI MapID="1188" xpos="369.976" ypos="32.120" zpos="53.264" GUID="a6gCOX4GC0CJfo9UZBapGQ==" type="Raid.W4.B1.c1.sc2"/>
     <!-- Timer -->
     <POI MapID="1188" xpos="0369.760" ypos="032.120" zpos="0060.162" GUID="X61Xv4ZCakilicnR4E+sHA==" type="Raid.W4.B1.c2"/>
     <!-- ==================== Mursaat Overseer ==================== -->

--- a/Blish HUD/SFTA.xml
+++ b/Blish HUD/SFTA.xml
@@ -1,5 +1,5 @@
 <OverlayData>
-    <MarkerCategory       name="raid" DisplayName="Raid">
+    <MarkerCategory       name="raid" DisplayName="Raids">
       <MarkerCategory     name="sfta" DisplayName="SFTA">
         <MarkerCategory   name="ele"  DisplayName="Elementalist" fadeFar="1500" fadeNear="1250">
           <MarkerCategory name="c1"   DisplayName="Tempest"                                     specialization="48"/>

--- a/Blish HUD/Strikes.xml
+++ b/Blish HUD/Strikes.xml
@@ -2,8 +2,8 @@
 <!-- =================================================== BLISH HUD VERSION ================================================== -->
 <!-- ======================================================================================================================== -->
 <OverlayData>
-  <MarkerCategory     name="Strike">
-    <MarkerCategory   name="Ti"   DisplayName="Hero's Marker Pack" IsSeparator="1"/>
+  <MarkerCategory     name="Strike" DisplayName="Strikes">
+    <MarkerCategory   name="Ti" DisplayName="Hero's Marker Pack" IsSeparator="1"/>
     <MarkerCategory   name="B1" DisplayName="Icebrood Construct" fadeFar="2500" fadeNear="2250"                                     iconSize="0.5">
       <MarkerCategory name="c1" DisplayName="Phase 1"                                           iconFile="Data/Strikes/IC/dot1.png"                rotate-x="180"/>
       <MarkerCategory name="c2" DisplayName="Phase 2"                                           iconFile="Data/Strikes/IC/dot2.png"                rotate-x="180"/>


### PR DESCRIPTION
- Removed variant 2 of Urban Battleground's Barricade Skip.
- Renamed Aetherblade's skip (in the category name) to 'Electric Skip'.
- Added Guardian support for Aetherblade's Electric Skip.
- Swapped thief portal pictures around to make more sense.
- Added a skip to Old Tom; this supports Elementalist, Guardian, Mesmer, Necromancer, and Thief.
- Fixed an issue where Mesmer's portal icons weren't showing for Volcanic's Portal skip.
- Renamed the main 'Raid' category to 'Raids'.
- Added `defaultToggles` to Slothasor's Mushroom markers so when a strategy is enabled, it doesn't display all markers (only the first shroom).
- Added support for the two main Agony Strategies in Cairn; Kite and No-Kite. By default 'Kite' is enabled.
- Reduced the duration of Twin Largos' markers to fall down faster with the platform.
- Strike's category name is now called 'Strikes'.